### PR TITLE
docs(ai): add Dependabot vulnerability warning rule to global git instructions

### DIFF
--- a/ai/global/git.instructions.md
+++ b/ai/global/git.instructions.md
@@ -67,3 +67,16 @@ fi
 
 - Use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format for all commit messages.
 - Always include the user's original prompt verbatim in the commit description (body), prefixed with `Prompt: `. Do not include it in the commit title.
+
+## Dependabot Vulnerability Warnings
+
+- After any push, if the remote prints a message like:
+  ```
+  remote: GitHub found N vulnerabilities on <repo>'s default branch (X critical, Y high, ...).
+  remote:      https://github.com/<repo>/security/dependabot
+  ```
+  check whether there are already open Dependabot PRs covering those vulnerabilities (`gh pr list --label dependencies`).
+- If there are no open Dependabot PRs (or they do not cover all flagged advisories), visit `https://github.com/<repo>/security/dependabot`, review each unfixed advisory, and for any where a manual fix is possible create a GitHub Issue that:
+  - Names the vulnerable package and the severity.
+  - Describes the steps to fix it manually.
+  - Is labelled `Security` and `AI-Work`.


### PR DESCRIPTION
## Summary

- Adds a **Dependabot Vulnerability Warnings** section to `ai/global/git.instructions.md`.
- After any push that shows a GitHub vulnerability warning, the rule requires checking for open Dependabot PRs. If none cover the flagged advisories, visit the security tab and create GitHub Issues labelled `Security` and `AI-Work` for any vulnerabilities that have manual fixes available.

## Test plan

- [ ] Rule is visible in `ai/global/git.instructions.md`
- [ ] Wording is consistent with the style of the rest of the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)