### PR TITLE
docs(ai): add template rule escalation process to global git instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 
 ## [Unreleased]
 ### Added
-- Added template rule escalation process to global git instructions: when working in a non-template repo, gaps in template rules should be raised as `AI-Work` issues in `credfeto/cs-template`.
 ### Fixed
 ### Changed
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 
 ## [Unreleased]
 ### Added
+- Added template rule escalation process to global git instructions: when working in a non-template repo, gaps in template rules should be raised as `AI-Work` issues in `credfeto/cs-template`.
 ### Fixed
 ### Changed
 ### Deprecated

--- a/ai/global/git.instructions.md
+++ b/ai/global/git.instructions.md
@@ -91,3 +91,25 @@ fi
   - Names the vulnerable package and the severity.
   - Describes the steps to fix it manually.
   - Is labelled `Security` and `AI-Work`.
+
+## Template Rule Escalation (Non-Template Repos Only)
+
+This section applies **only when working in a non-template repository** (i.e., any repo other than `credfeto/cs-template`).
+
+If, during work in a non-template repo, a gap or needed change is identified in the global template rules or instructions:
+
+1. **Do not** apply the rule change locally — template rules are managed centrally in `credfeto/cs-template`.
+2. Create a new issue in `credfeto/cs-template` using the GitHub CLI:
+   ```bash
+   gh issue create --repo credfeto/cs-template \
+     --title "<short description of the rule change>" \
+     --label "AI-Work" \
+     --body "..."
+   ```
+3. The issue body **must** include all of the following:
+   - **Source repository**: The repo where the need was discovered.
+   - **Current behaviour / gap**: What is missing or inconsistent in the existing rules.
+   - **Proposed rule text**: The concrete rule update or new instruction text being requested.
+   - **Reason for template propagation**: Why this change should apply across all repos, not just locally.
+4. After creating the issue, note its URL in any relevant commit or PR description so the context is not lost.
+5. Continue work in the current repo without waiting for the template issue to be resolved.


### PR DESCRIPTION
## Summary

Closes #742

- Adds a new **Template Rule Escalation** section to `ai/global/git.instructions.md`
- Scoped explicitly to non-template repositories only
- Defines the workflow: when a template rule gap is found in a non-template repo, create an `AI-Work` issue in `credfeto/cs-template` rather than applying changes locally
- Specifies the minimum required issue content: source repo, current behaviour/gap, proposed rule text, and reason for template propagation
- Updated `CHANGELOG.md` with the addition

## Test plan

- [ ] Review `ai/global/git.instructions.md` for clarity and completeness of the new section
- [ ] Confirm the rule is clearly scoped to non-template repos only
- [ ] Confirm the `AI-Work` label requirement is explicitly stated
- [ ] Confirm minimum required issue content fields are all present

🤖 Generated with [Claude Code](https://claude.com/claude-code)