### PR TITLE
docs(ai): add NuGet vulnerability suppression policy to .NET instructions

### DIFF
--- a/ai/global/dotnet.instructions.md
+++ b/ai/global/dotnet.instructions.md
@@ -88,3 +88,35 @@ Never push code that does not compile. If you cannot fix a build error, report i
 - All value types (records declared with positional parameters or `record struct`) must have a `[DebuggerDisplay("...")]` attribute.
 - All configuration/options classes (typically bound from `appsettings.json`) must have a `[DebuggerDisplay("...")]` attribute showing their key properties.
 - The `DebuggerDisplay` format string should show the most useful identifying information — typically a name, identifier, or URL.
+
+## NuGet Vulnerability Suppression
+
+Accepted NuGet security advisories must be suppressed **at the project level** using the specific advisory URL, not suppressed globally in shared props.
+
+### Required: project-level suppression
+
+Suppress each accepted advisory in the affected `.csproj` file using `<NuGetAuditSuppress>`:
+
+```xml
+<ItemGroup>
+  <!-- Reason: <brief explanation of why this advisory is accepted> -->
+  <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-xxxx-xxxx-xxxx" />
+</ItemGroup>
+```
+
+### Prohibited: global suppression
+
+Do **not** suppress NuGet vulnerability warnings globally in shared `.props` files or `Directory.Build.props`. The following patterns are **explicitly prohibited**:
+
+```xml
+<!-- PROHIBITED: broad suppression in shared props -->
+<WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+<NoWarn>NU1901;NU1902;NU1903;NU1904</NoWarn>
+```
+
+### Rationale
+
+Global suppression hides newly introduced advisories as packages are updated. Per-advisory project-level suppression ensures that:
+- Only explicitly reviewed and accepted vulnerabilities are suppressed.
+- New advisories on updated packages are not silently ignored.
+- Each suppression is traceable to a specific advisory URL and kept in the project file where the affected package is referenced.

--- a/ai/global/index.md
+++ b/ai/global/index.md
@@ -25,6 +25,6 @@ This is an index of global instructions that apply to all projects.
 | [security.instructions.md](security.instructions.md) | No secrets in code, input validation, output sanitisation, threat modelling, vulnerability scanning |
 | [error-handling.instructions.md](error-handling.instructions.md) | Explicit error handling, no swallowed exceptions, propagation and safe surfacing of errors |
 | [logging.instructions.md](logging.instructions.md) | Structured logging, log levels, what to log and what not to log (no PII, no secrets) |
-| [dotnet.instructions.md](dotnet.instructions.md) | .NET-specific: build and test before commit (`dotnet build`/`dotnet test`), solution structure, test assembly naming, FunFair.Test.Common, FunFair.BuildCheck |
+| [dotnet.instructions.md](dotnet.instructions.md) | .NET-specific: build and test before commit (`dotnet build`/`dotnet test`), solution structure, test assembly naming, FunFair.Test.Common, FunFair.BuildCheck, project-level NuGetAuditSuppress (no global NU19xx suppression) |
 | [task-workflow.instructions.md](task-workflow.instructions.md) | Issue/PR assignment, splitting large tasks into sub-issues worked one at a time, file status tracking, commit/push cadence, multi-agent routing (Code Writer → Code Tester → Code Reviewer → Changelog → Committer), resuming interrupted work |
  


### PR DESCRIPTION
## Summary

- Adds explicit NuGet vulnerability suppression policy to `.NET instructions` addressing issue #741
- Requires project-level `<NuGetAuditSuppress>` with specific advisory URLs in the affected `.csproj`
- Explicitly prohibits broad/global NU19xx suppression via `WarningsNotAsErrors` or `NoWarn` in shared props
- Updates index description for `dotnet.instructions.md` to mention the new rule

## Changes

- `ai/global/dotnet.instructions.md` — new **NuGet Vulnerability Suppression** section with required pattern, prohibited pattern, and rationale
- `ai/global/index.md` — updated description row for `dotnet.instructions.md`

## Test plan

- [ ] No CHANGELOG update (cs-template does not maintain a changelog)
- [ ] CI lint checks pass
- [ ] Instructions are internally consistent with existing NuGet/package guidance

Closes #741

🤖 Generated with [Claude Code](https://claude.com/claude-code)