### PR TITLE
build: run FunFair.BuildCheck as a parallel step in .NET CI builds

### DIFF
--- a/.github/workflows/build-and-publish-pre-release.yml
+++ b/.github/workflows/build-and-publish-pre-release.yml
@@ -168,3 +168,49 @@ jobs:
           script: |
             core.info('Version: \u001b[38;5;6m${{env.BUILD_VERSION}}');
             core.notice('Version: ${{env.BUILD_VERSION}}');
+
+  buildcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Initialise Workspace"
+        if: runner.environment == 'self-hosted'
+        shell: bash
+        run: sudo chown -R "$USER:$USER" "$GITHUB_WORKSPACE"
+
+      - name: "Checkout Source"
+        uses: actions/checkout@v6.0.2
+        with:
+          clean: true
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: "Check file existence"
+        id: check_files
+        shell: bash
+        run: |
+          {
+          [[ -d src && -f src/global.json && '${{hashfiles('**/*.sln', '**/*.slnx')}}' != '' ]] && echo 'SLN_EXIST=true' || echo 'SLN_EXIST=false';
+          } >> "$GITHUB_OUTPUT"
+
+      - name: "Install dotnet"
+        if: steps.check_files.outputs.SLN_EXIST == 'true'
+        uses: ./.github/actions/dotnet-install
+        with:
+          GITHUB_TOKEN: ${{secrets.SOURCE_PUSH_TOKEN}}
+          NUGET_PUBLIC_RESTORE_FEED: ${{vars.NUGET_PUBLIC_RESTORE_FEED || 'https://api.nuget.org/v3/index.json'}}
+          NUGET_ADDITIONAL_RESTORE_FEED_RELEASE: ${{vars.NUGET_ADDITIONAL_RESTORE_FEED_RELEASE}}
+          NUGET_ADDITIONAL_RESTORE_FEED_PRERELEASE: ${{vars.NUGET_ADDITIONAL_RESTORE_FEED_PRERELEASE}}
+
+      - name: "Install FunFair.BuildCheck"
+        if: steps.check_files.outputs.SLN_EXIST == 'true'
+        uses: ./.github/actions/dotnet-tool
+        with:
+          TOOL_NAME: "FunFair.BuildCheck"
+          TOOL_VERSION: "latest"
+
+      - name: "Run Build Check"
+        if: steps.check_files.outputs.SLN_EXIST == 'true'
+        uses: ./.github/actions/dotnet-build-check
+        with:
+          RELEASE: "false"

--- a/.github/workflows/build-and-publish-release.yml
+++ b/.github/workflows/build-and-publish-release.yml
@@ -155,3 +155,49 @@ jobs:
           script: |
             core.info('Version: \u001b[38;5;6m${{env.BUILD_VERSION}}');
             core.notice('Version: ${{env.BUILD_VERSION}}');
+
+  buildcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Initialise Workspace"
+        if: runner.environment == 'self-hosted'
+        shell: bash
+        run: sudo chown -R "$USER:$USER" "$GITHUB_WORKSPACE"
+
+      - name: "Checkout Source"
+        uses: actions/checkout@v6.0.2
+        with:
+          clean: true
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: "Check file existence"
+        id: check_files
+        shell: bash
+        run: |
+          {
+          [[ -d src && -f src/global.json && '${{hashfiles('**/*.sln', '**/*.slnx')}}' != '' ]] && echo 'SLN_EXIST=true' || echo 'SLN_EXIST=false';
+          } >> "$GITHUB_OUTPUT"
+
+      - name: "Install dotnet"
+        if: steps.check_files.outputs.SLN_EXIST == 'true'
+        uses: ./.github/actions/dotnet-install
+        with:
+          GITHUB_TOKEN: ${{secrets.SOURCE_PUSH_TOKEN}}
+          NUGET_PUBLIC_RESTORE_FEED: ${{vars.NUGET_PUBLIC_RESTORE_FEED || 'https://api.nuget.org/v3/index.json'}}
+          NUGET_ADDITIONAL_RESTORE_FEED_RELEASE: ${{vars.NUGET_ADDITIONAL_RESTORE_FEED_RELEASE}}
+          NUGET_ADDITIONAL_RESTORE_FEED_PRERELEASE: ${{vars.NUGET_ADDITIONAL_RESTORE_FEED_PRERELEASE}}
+
+      - name: "Install FunFair.BuildCheck"
+        if: steps.check_files.outputs.SLN_EXIST == 'true'
+        uses: ./.github/actions/dotnet-tool
+        with:
+          TOOL_NAME: "FunFair.BuildCheck"
+          TOOL_VERSION: "latest"
+
+      - name: "Run Build Check"
+        if: steps.check_files.outputs.SLN_EXIST == 'true'
+        uses: ./.github/actions/dotnet-build-check
+        with:
+          RELEASE: "true"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 
 ## [Unreleased]
 ### Added
+- build: run FunFair.BuildCheck as a parallel job in CI builds for faster feedback on project-structure violations
 ### Fixed
 ### Changed
 ### Deprecated


### PR DESCRIPTION
## Summary

Closes #746

- Adds a `buildcheck` job to `build-and-publish-pre-release.yml` and `build-and-publish-release.yml` that runs in parallel with the main build job
- Checks out source, installs .NET tooling, installs `FunFair.BuildCheck`, and runs `dotnet-build-check`
- Uses the existing `.github/actions/dotnet-build-check` composite action
- `RELEASE: "false"` for pre-release builds, `RELEASE: "true"` for release builds
- Skipped gracefully when no `.sln`/`.slnx` file is found in `src/`

## Test plan

- [ ] Verify the `buildcheck` job appears and runs in parallel on the next push to a feature branch
- [ ] Confirm it passes on a project that satisfies all FunFair.BuildCheck rules
- [ ] Confirm it fails fast on a project-structure violation before the full build completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)