### PR TITLE
build: run FunFair.BuildCheck as a parallel job in .NET CI builds

### DIFF
--- a/.github/actions/dotnet/action.yml
+++ b/.github/actions/dotnet/action.yml
@@ -83,12 +83,6 @@ runs:
       shell: bash
       run: echo "DOTNET_RELEASE_DEFINES=-p:IsProduction=True" >> "$GITHUB_ENV"
 
-    - name: "Dotnet: Run build check"
-      if: ${{ (!endsWith(github.repository, 'funfair-dotnet-build-check')) && (!endsWith(github.repository, '-template')) }}
-      uses: ./.github/actions/dotnet-build-check
-      with:
-        RELEASE: ${{inputs.RELEASE}}
-
     - name: "Dotnet: Override code analysis rules"
       if: ${{ !endsWith(github.repository, '-template') }}
       uses: ./.github/actions/dotnet-code-analysis-override

--- a/.github/workflows/build-and-publish-pre-release.yml
+++ b/.github/workflows/build-and-publish-pre-release.yml
@@ -168,3 +168,77 @@ jobs:
           script: |
             core.info('Version: \u001b[38;5;6m${{env.BUILD_VERSION}}');
             core.notice('Version: ${{env.BUILD_VERSION}}');
+
+  buildcheck:
+    if: ${{ !endsWith(github.repository, '-template') && !endsWith(github.repository, 'funfair-dotnet-build-check') }}
+
+    runs-on: ubuntu-latest
+
+    env:
+      # Nuget caching
+      USE_NUGET_CACHE: ${{vars.USE_NUGET_CACHE}}
+      NUGET_BAGET_CACHE: ''
+
+    steps:
+      - name: "Initialise Workspace"
+        if: runner.environment == 'self-hosted'
+        shell: bash
+        run: sudo chown -R "$USER:$USER" "$GITHUB_WORKSPACE"
+
+      - name: "Set Active Environment"
+        shell: bash
+        run: |
+          {
+            echo "ACTIVE_RUNNER_NAME=${{runner.name}}"
+            echo "ACTIVE_HOSTNAME=$HOSTNAME"
+            echo "ACTIVE_USER=$USER"
+            echo "TEMP=${{runner.temp}}"
+            echo "TMP=${{runner.temp}}"
+          } >> "$GITHUB_ENV"
+
+      - name: "Checkout Source"
+        uses: actions/checkout@v6.0.2
+        with:
+          clean: true
+          fetch-depth: 0
+          fetch-tags: true
+
+      - if: env.USE_NUGET_CACHE == ''
+        name: "Setup Nuget Cache (Cache disabled)"
+        shell: bash
+        run: echo "USE_NUGET_CACHE=false" >> "$GITHUB_ENV"
+
+      - if: runner.environment != 'self-hosted'
+        name: "Ensure on github agents nuget cache is disabled"
+        shell: bash
+        run: echo "USE_NUGET_CACHE=false" >> "$GITHUB_ENV"
+
+      - name: "Enable Local nuget/npm feeds if caching"
+        if: env.USE_NUGET_CACHE == 'true'
+        shell: bash
+        run: |
+          {
+            echo "NUGET_BAGET_CACHE=${{vars.NUGET_BAGET_CACHE}}"
+          }>> "$GITHUB_ENV"
+
+      - name: "Install dotnet"
+        uses: ./.github/actions/dotnet-install
+        with:
+          GITHUB_TOKEN: ${{secrets.SOURCE_PUSH_TOKEN}}
+          NUGET_PUBLIC_RESTORE_FEED_CACHE: ${{env.NUGET_BAGET_CACHE}}
+          NUGET_PUBLIC_RESTORE_FEED: ${{vars.NUGET_PUBLIC_RESTORE_FEED || 'https://api.nuget.org/v3/index.json'}}
+          NUGET_ADDITIONAL_RESTORE_FEED_RELEASE_CACHE: ''
+          NUGET_ADDITIONAL_RESTORE_FEED_PRERELEASE_CACHE: ''
+          NUGET_ADDITIONAL_RESTORE_FEED_RELEASE: ${{vars.NUGET_ADDITIONAL_RESTORE_FEED_RELEASE}}
+          NUGET_ADDITIONAL_RESTORE_FEED_PRERELEASE: ${{vars.NUGET_ADDITIONAL_RESTORE_FEED_PRERELEASE}}
+
+      - name: "Install Dotnet Build Check tool"
+        uses: ./.github/actions/dotnet-tool
+        with:
+          TOOL_NAME: "FunFair.BuildCheck"
+          TOOL_VERSION: "latest"
+
+      - name: "Run Dotnet Build Check"
+        uses: ./.github/actions/dotnet-build-check
+        with:
+          RELEASE: "false"

--- a/.github/workflows/build-and-publish-release.yml
+++ b/.github/workflows/build-and-publish-release.yml
@@ -155,3 +155,77 @@ jobs:
           script: |
             core.info('Version: \u001b[38;5;6m${{env.BUILD_VERSION}}');
             core.notice('Version: ${{env.BUILD_VERSION}}');
+
+  buildcheck:
+    if: ${{ !endsWith(github.repository, '-template') && !endsWith(github.repository, 'funfair-dotnet-build-check') }}
+
+    runs-on: ubuntu-latest
+
+    env:
+      # Nuget caching
+      USE_NUGET_CACHE: ${{vars.USE_NUGET_CACHE}}
+      NUGET_BAGET_CACHE: ''
+
+    steps:
+      - name: "Initialise Workspace"
+        if: runner.environment == 'self-hosted'
+        shell: bash
+        run: sudo chown -R "$USER:$USER" "$GITHUB_WORKSPACE"
+
+      - name: "Set Active Environment"
+        shell: bash
+        run: |
+          {
+            echo "ACTIVE_RUNNER_NAME=${{runner.name}}"
+            echo "ACTIVE_HOSTNAME=$HOSTNAME"
+            echo "ACTIVE_USER=$USER"
+            echo "TEMP=${{runner.temp}}"
+            echo "TMP=${{runner.temp}}"
+          } >> "$GITHUB_ENV"
+
+      - name: "Checkout Source"
+        uses: actions/checkout@v6.0.2
+        with:
+          clean: true
+          fetch-depth: 0
+          fetch-tags: true
+
+      - if: env.USE_NUGET_CACHE == ''
+        name: "Setup Nuget Cache (Cache disabled)"
+        shell: bash
+        run: echo "USE_NUGET_CACHE=false" >> "$GITHUB_ENV"
+
+      - if: runner.environment != 'self-hosted'
+        name: "Ensure on github agents nuget cache is disabled"
+        shell: bash
+        run: echo "USE_NUGET_CACHE=false" >> "$GITHUB_ENV"
+
+      - name: "Enable Local nuget/npm feeds if caching"
+        if: env.USE_NUGET_CACHE == 'true'
+        shell: bash
+        run: |
+          {
+            echo "NUGET_BAGET_CACHE=${{vars.NUGET_BAGET_CACHE}}"
+          }>> "$GITHUB_ENV"
+
+      - name: "Install dotnet"
+        uses: ./.github/actions/dotnet-install
+        with:
+          GITHUB_TOKEN: ${{secrets.SOURCE_PUSH_TOKEN}}
+          NUGET_PUBLIC_RESTORE_FEED_CACHE: ${{env.NUGET_BAGET_CACHE}}
+          NUGET_PUBLIC_RESTORE_FEED: ${{vars.NUGET_PUBLIC_RESTORE_FEED || 'https://api.nuget.org/v3/index.json'}}
+          NUGET_ADDITIONAL_RESTORE_FEED_RELEASE_CACHE: ''
+          NUGET_ADDITIONAL_RESTORE_FEED_PRERELEASE_CACHE: ''
+          NUGET_ADDITIONAL_RESTORE_FEED_RELEASE: ${{vars.NUGET_ADDITIONAL_RESTORE_FEED_RELEASE}}
+          NUGET_ADDITIONAL_RESTORE_FEED_PRERELEASE: ''
+
+      - name: "Install Dotnet Build Check tool"
+        uses: ./.github/actions/dotnet-tool
+        with:
+          TOOL_NAME: "FunFair.BuildCheck"
+          TOOL_VERSION: "latest"
+
+      - name: "Run Dotnet Build Check"
+        uses: ./.github/actions/dotnet-build-check
+        with:
+          RELEASE: "true"


### PR DESCRIPTION
## Summary

- Adds a dedicated `buildcheck` job to both `build-and-publish-pre-release.yml` and `build-and-publish-release.yml` that runs in **parallel** with the main build job
- Removes the sequential buildcheck step from `.github/actions/dotnet/action.yml` to avoid running twice
- The parallel job checks out source, installs .NET and `FunFair.BuildCheck`, then runs `dotnet-build-check`
- Skipped automatically on `-template` and `funfair-dotnet-build-check` repositories (same exclusions as before)

## Test plan

- [ ] Verify `buildcheck` job appears as a separate parallel job in CI for derived .NET repos
- [ ] Confirm `buildcheck` job is skipped/not present in the template repo itself
- [ ] Confirm the main `build-pre-release` / `build-release` job no longer runs buildcheck sequentially
- [ ] Verify buildcheck failures surface independently and faster than the full build

Closes #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)