### PR TITLE
docs(ai): add rule that README configuration docs must be kept in sync with config changes

### DIFF
--- a/ai/global/documentation.instructions.md
+++ b/ai/global/documentation.instructions.md
@@ -14,6 +14,12 @@
   - Link to the security policy — use the standard filename (`SECURITY.md`).
   - Link to `CHANGELOG.md`.
 
+## Configuration Documentation
+
+- Whenever a configuration option is added, removed, or renamed (in `appsettings.json`, an options class, or environment variable mapping), the corresponding section in `README.md` must be updated in the same commit.
+- The `README.md` configuration section must accurately reflect all current options, their types, default values, and a brief description of what each does.
+- This applies to any project that has a `README.md` with a configuration or setup section.
+
 ## CHANGELOG
 
 - Maintain `CHANGELOG.md` in [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format to track changes and updates to the project.


### PR DESCRIPTION
## Summary

Closes #749

Adds a **Configuration Documentation** rule to `ai/global/documentation.instructions.md` requiring that `README.md` configuration sections are kept in sync whenever configuration options change.

Identified during review of [credfeto/credfeto-dispatcher#5](https://github.com/credfeto/credfeto-dispatcher/pull/5).

## Changes

- Added `## Configuration Documentation` section to `ai/global/documentation.instructions.md`
- Rule requires README config docs to be updated in the same commit as any option addition, removal, or rename
- Applies to any project with a README configuration section

🤖 Generated with [Claude Code](https://claude.com/claude-code)