### PR TITLE
fix: die() must output to stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,14 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 -->
 
 ## [Unreleased]
+### Security
 ### Added
 ### Fixed
 ### Changed
+- die() must output to stderr so error messages are not swallowed by stdout pipelines
 ### Deprecated
 ### Removed
-### Security
 ### Deployment Changes
-
 <!--
 Releases that have at least been deployed to staging, BUT NOT necessarily released to live.  Changes should be moved from [Unreleased] into here as they are merged into the appropriate release branch
 -->

--- a/ai/global/shell-scripts.instructions.md
+++ b/ai/global/shell-scripts.instructions.md
@@ -22,10 +22,12 @@ Use consistent coloured prefixes for outcome messages so that success and failur
 
 ```sh
 die() {
-    printf '\n\033[31m✗\033[0m %s\n' "$*"
+    printf '\n\033[31m✗\033[0m %s\n' "$*" >&2
     exit 1
 }
 ```
+
+Always direct `die()` output to stderr (`>&2`) so error messages are not captured by stdout pipelines and remain visible even when stdout is redirected.
 
 - **Success** — prefix with a green `✓`:
 


### PR DESCRIPTION
## Summary

- Updated `die()` in `ai/global/shell-scripts.instructions.md` to redirect output to stderr (`>&2`)
- Added explanatory note: error messages must not be captured by stdout pipelines
- Fixed CHANGELOG.md section ordering and added entry

Closes #772

🤖 Generated with [Claude Code](https://claude.com/claude-code)