### PR TITLE
feat: add rule for handling deprecation warnings during tests

### DIFF
--- a/ai/global/code-quality.instructions.md
+++ b/ai/global/code-quality.instructions.md
@@ -48,6 +48,20 @@ Prefer parameterised tests over duplicated test methods — each behavioural var
 
 Cover compile-time configuration (environment constants, build-time feature flags) with unit tests — not runtime assertions, which pollute production code.
 
+## Deprecation Warnings During Tests
+
+When deprecation warnings appear in test output (e.g. framework or runtime warnings about deprecated APIs):
+
+- **If the warning is new and caused by your change** — fix the deprecation before committing; do not leave it for later.
+- **If the warning is pre-existing and not caused by your change** — raise a GitHub issue in the current repository with:
+  - A clear title describing the deprecated API.
+  - The full warning text.
+  - The component or dependency responsible.
+  - What needs to be done to resolve it.
+  - Label the issue `AI-Work`.
+
+Do not suppress or ignore deprecation warnings.
+
 ## Code Complexity
 
 - Prefer clean code — readable, well-named, single-responsibility.

--- a/ai/global/code-quality.instructions.md
+++ b/ai/global/code-quality.instructions.md
@@ -53,12 +53,14 @@ Cover compile-time configuration (environment constants, build-time feature flag
 When deprecation warnings appear in test output (e.g. framework or runtime warnings about deprecated APIs):
 
 - **If the warning is new and caused by your change** — fix the deprecation before committing; do not leave it for later.
-- **If the warning is pre-existing and not caused by your change** — raise a GitHub issue in the current repository with:
-  - A clear title describing the deprecated API.
-  - The full warning text.
-  - The component or dependency responsible.
-  - What needs to be done to resolve it.
-  - Label the issue `AI-Work`.
+- **If the warning is pre-existing and not caused by your change** — first check for an existing open GitHub issue in the current repository covering the same warning (for example by searching for the deprecated API, the warning text, and the affected component or dependency).
+  - If a matching open issue already exists, update it with any new context you found or reference it in your work; do not create a duplicate issue.
+  - If no matching open issue exists, raise a new GitHub issue in the current repository with:
+    - A clear title describing the deprecated API.
+    - The full warning text.
+    - The component or dependency responsible.
+    - What needs to be done to resolve it.
+    - Label the issue `AI-Work`.
 
 Do not suppress or ignore deprecation warnings.
 


### PR DESCRIPTION
Adds a new rule to `code-quality.instructions.md` instructing the AI to:

- Fix deprecation warnings that are new and caused by its own changes before committing.
- Raise a GitHub issue labelled `AI-Work` for pre-existing deprecation warnings, including full warning text, responsible component, and resolution notes.