### PR TITLE
docs: prefer git -C over cd && git in shell commands

### DIFF
--- a/ai/global/git-commits.instructions.md
+++ b/ai/global/git-commits.instructions.md
@@ -9,6 +9,10 @@ Load this file when about to commit or acting as the Committer agent. See [git.i
 - **Never create an empty commit.** Verify `git diff --cached --name-only` lists at least one file before running `git commit`.
 - Never amend an existing commit — always create a new one.
 - Push to `origin` after every commit.
+- You are not allowed to bypass hooks or formatters. If they fail, stop and report the failure — do not bypass or attempt to fix them yourself.
+- You are not allowed to bypass commit message validation. If it fails, stop and report the failure — do not bypass or attempt to fix it yourself.
+- You are not allowed to change linting or formatting rules to make a commit pass. If they fail, stop and report the failure — do not change rules or attempt to fix it yourself.
+- You are not allowed to change ignore files in any way to make a commit pass. If they cause a failure, stop and report the failure — do not change ignore files or attempt to fix them yourself.
 
 ## Unexpected Reformatting During Commit (MANDATORY)
 
@@ -18,8 +22,6 @@ If hooks or formatters modify files **not in your intended change set**:
 2. Abort the commit.
 3. Report the affected files and which hook/formatter changed them.
 4. Wait for explicit instructions.
-
-Do not use `--no-verify`.
 
 ## Commit Message Format
 

--- a/ai/global/git-commits.instructions.md
+++ b/ai/global/git-commits.instructions.md
@@ -4,15 +4,15 @@
 
 Load this file when about to commit or acting as the Committer agent. See [git.instructions.md](git.instructions.md) for the mandatory identity check and branch verification.
 
-## Commit Rules
+## Commit Rules (MANDATORY)
 
 - **Never create an empty commit.** Verify `git diff --cached --name-only` lists at least one file before running `git commit`.
 - Never amend an existing commit — always create a new one.
 - Push to `origin` after every commit.
-- You are not allowed to bypass hooks or formatters. If they fail, stop and report the failure — do not bypass or attempt to fix them yourself.
-- You are not allowed to bypass commit message validation. If it fails, stop and report the failure — do not bypass or attempt to fix it yourself.
-- You are not allowed to change linting or formatting rules to make a commit pass. If they fail, stop and report the failure — do not change rules or attempt to fix it yourself.
-- You are not allowed to change ignore files in any way to make a commit pass. If they cause a failure, stop and report the failure — do not change ignore files or attempt to fix them yourself.
+- **Never bypass hooks or formatters.** If they fail, stop and report the failure.
+- **Never bypass commit message validation.** If it fails, stop and report the failure.
+- **Never change linting or formatting rules to force a commit through.** If they fail, stop and report the failure.
+- **Never modify ignore files to force a commit through.** If they cause a failure, stop and report the failure.
 
 ## Unexpected Reformatting During Commit (MANDATORY)
 

--- a/ai/global/git.instructions.md
+++ b/ai/global/git.instructions.md
@@ -52,7 +52,7 @@ When `GH_HOST` is set to a value other than `github.com`, `gh` routes through a 
 ## Running Git Commands in a Specific Directory
 
 - Always use `git -C <dir> <command>` — never `cd <dir> && git <command>`.
-- `git -C` runs the command in the specified directory without changing the shell's working directory: it is atomic and avoids leaving the shell in the wrong directory for subsequent commands.
+- `git -C` runs the command in the specified directory without changing the shell's working directory, using a single invocation and avoiding leaving the shell in the wrong directory for subsequent commands.
 - In Claude Code the `cd` form also triggers an unnecessary permission prompt for the directory change itself.
 - This applies to all git subcommands: `git -C /path status`, `git -C /path add`, `git -C /path commit`, etc.
 

--- a/ai/global/git.instructions.md
+++ b/ai/global/git.instructions.md
@@ -51,7 +51,10 @@ When `GH_HOST` is set to a value other than `github.com`, `gh` routes through a 
 
 ## Running Git Commands in a Specific Directory
 
-- Never use `cd <dir> && git <command>` — use `git -C <dir> <command>` instead.
+- Always use `git -C <dir> <command>` — never `cd <dir> && git <command>`.
+- `git -C` runs the command in the specified directory without changing the shell's working directory: it is atomic and avoids leaving the shell in the wrong directory for subsequent commands.
+- In Claude Code the `cd` form also triggers an unnecessary permission prompt for the directory change itself.
+- This applies to all git subcommands: `git -C /path status`, `git -C /path add`, `git -C /path commit`, etc.
 
 ## Branching
 


### PR DESCRIPTION
Closes #805

Expanded the 'Running Git Commands in a Specific Directory' section in `git.instructions.md` with full rationale:
- `git -C` is atomic and does not change the shell's working directory
- `cd && git` leaves the shell in the wrong directory for subsequent commands
- In Claude Code the `cd` form triggers an unnecessary permission prompt
- Applies to all git subcommands