### PR TITLE
chore: fix audit findings in ai/global instruction files

### DIFF
--- a/.ai-instructions
+++ b/.ai-instructions
@@ -22,5 +22,5 @@ Precedence is given to local instructions over global instructions.
 * If a memory file's description diverges from the source code, update it to reflect the changes.
 * Whenever rebasing from main, take the current branch's changes, but merge the changes in from main into the current fileset.
 * Whenever starting work - re-read all these files and use this as a basis for how the work is performed.
-* If work requires a missing CLI tool, see the **Missing CLI Tools** section in `ai/global/git.instructions.md`.
+* If work requires a missing CLI tool, see the **Missing CLI Tools** section in `ai/global/task-workflow.instructions.md`.
 * This file (.ai-instructions) should only be edited in [git@github.com:credfeto/cs-template.git](https://github.com/credfeto/cs-template).

--- a/.ai-instructions
+++ b/.ai-instructions
@@ -22,5 +22,5 @@ Precedence is given to local instructions over global instructions.
 * If a memory file's description diverges from the source code, update it to reflect the changes.
 * Whenever rebasing from main, take the current branch's changes, but merge the changes in from main into the current fileset.
 * Whenever starting work - re-read all these files and use this as a basis for how the work is performed.
-* If work requires a missing CLI tool, **stop and ask the user to install it** — do not attempt to find, locate, or install it automatically. Do not spend time searching for alternative paths or making random installs.
+* If work requires a missing CLI tool, see the **Missing CLI Tools** section in `ai/global/git.instructions.md`.
 * This file (.ai-instructions) should only be edited in [git@github.com:credfeto/cs-template.git](https://github.com/credfeto/cs-template).

--- a/ai/global/agent-roles.instructions.md
+++ b/ai/global/agent-roles.instructions.md
@@ -50,7 +50,7 @@ Invoked by: Code Writer, Code Fixer, Code Reviewer, CI Debugger.
 
 ### Code Reviewer: **Reuse**
 
-- Identify opportunities to reuse existing code instead of writing new code. Focus only on newly changed code.
+- Identify opportunities to reuse existing code instead of writing new code. Scope: newly changed code for Code Reviewer; full file set when dispatched by Repo Auditor.
 
 #### Reuse — Critical Instructions
 
@@ -67,7 +67,7 @@ Invoked by: Code Writer, Code Fixer, Code Reviewer, CI Debugger.
 
 ### Code Reviewer: **Quality**
 
-- Identify code quality issues in newly changed code.
+- Identify code quality issues. Scope: newly changed code for Code Reviewer; full file set when dispatched by Repo Auditor.
 
 #### Quality — Critical Instructions
 
@@ -84,7 +84,7 @@ Invoked by: Code Writer, Code Fixer, Code Reviewer, CI Debugger.
 
 ### Code Reviewer: **Efficiency**
 
-- Identify inefficiencies in newly changed code.
+- Identify inefficiencies. Scope: newly changed code for Code Reviewer; full file set when dispatched by Repo Auditor.
 
 #### Efficiency — Critical Instructions
 
@@ -101,7 +101,7 @@ Invoked by: Code Writer, Code Fixer, Code Reviewer, CI Debugger.
 
 ### Code Reviewer: **Correctness**
 
-- Identify logic errors in newly changed code.
+- Identify logic errors. Scope: newly changed code for Code Reviewer; full file set when dispatched by Repo Auditor.
 
 #### Correctness — Critical Instructions
 
@@ -115,11 +115,10 @@ Invoked by: Code Writer, Code Fixer, Code Reviewer, CI Debugger.
 - Conditionals: incorrect boolean logic, missing negation, wrong operator.
 - Edge cases: null/empty input, zero values, empty collections, missing default cases.
 - Business logic: code that does not match the intent described in the issue or PR.
-- Rule Breaking: there should not be any files that change the linting rules or building rules that weaken the repo.
 
 ### Code Reviewer: **Security**
 
-- Perform a security-focused code review to identify HIGH-CONFIDENCE security vulnerabilities that could have real exploitation potential. Focus only on security implications newly added by the PR.
+- Perform a security-focused review to identify HIGH-CONFIDENCE security vulnerabilities with real exploitation potential. Scope: security implications newly added by the PR for Code Reviewer; full file set when dispatched by Repo Auditor.
 
 #### Security — Critical Instructions
 
@@ -136,7 +135,7 @@ Invoked by: Code Writer, Code Fixer, Code Reviewer, CI Debugger.
 
 ### Code Reviewer: **Compliance**
 
-- Check that newly changed files comply with all applicable rules in the `.ai-instructions` instruction files.
+- Check that files comply with all applicable rules in the `.ai-instructions` instruction files. Scope: newly changed files for Code Reviewer; full file set when dispatched by Repo Auditor.
 
 #### Compliance — Critical Instructions
 
@@ -149,6 +148,7 @@ Invoked by: Code Writer, Code Fixer, Code Reviewer, CI Debugger.
 - Global rules: violations of rules in `ai/global/*.instructions.md` applicable to the changed file types.
 - Local rules: violations of rules in `ai/local/*.instructions.md` applicable to the changed file types — do not re-report violations already covered by global rules.
 - Rule hygiene: local rules in `ai/local/*.instructions.md` that duplicate or restate rules already present in `ai/global/*.instructions.md` — flag these for removal.
+- Rule Breaking: files that change linting rules or build rules in a way that weakens the repo's quality gates.
 - Language/framework rules: e.g. dotnet, shell, SQL instruction compliance where those files are present.
 - Documentation rules: README, CHANGELOG, and comment conventions from `documentation.instructions.md`.
 
@@ -212,7 +212,7 @@ Invoked by: Code Writer, Code Fixer, Code Reviewer, CI Debugger.
 - Wait up to 1 minute for GitHub to auto-create a PR (`gh pr list --head <branch>`); create one if absent.
 - Title: Conventional Commits format matching the primary commit. Body: summary + `Closes #<n>` (or `Related to #<n>`).
 - Update body if PR already exists. Add yourself as assignee.
-- Mark ready (`gh pr ready <number>`) only if Code Tester and Code Reviewer signed off — rebase first (`git fetch origin && git rebase origin/main`). Otherwise leave as draft.
+- Mark ready (`gh pr ready <number>`) only if Code Tester and Code Reviewer signed off — do not rebase here (hand off to Rebase Agent first if the branch needs rebasing). Otherwise leave as draft.
 
 ## CI Monitor _(not currently enabled)_
 

--- a/ai/global/changelog.instructions.md
+++ b/ai/global/changelog.instructions.md
@@ -6,7 +6,7 @@ Load this file when adding changelog entries or acting as the Changelog agent.
 
 ## Rules
 
-- Use `Credfeto.Changelog.Cmd` — never edit `CHANGELOG.md` manually.
+- Use `Credfeto.Changelog.Cmd` — never edit `CHANGELOG.md` manually. `Credfeto.Changelog.Cmd` is the dotnet tool package that provides the `dotnet changelog` command; no separate install step is required if the repo's dotnet tool manifest already includes it.
 - `CHANGELOG.md` must be listed in `.markdownlintignore` at the repo root (create the file if absent).
 - Entries must describe what changed and why it matters — not how it was implemented.
 

--- a/ai/global/documentation.instructions.md
+++ b/ai/global/documentation.instructions.md
@@ -1,7 +1,5 @@
 # Documentation Instructions
 
-> Load when: writing code, documentation, comments, or commit messages.
-
 [Back to Global Instructions Index](index.md)
 
 ## README

--- a/ai/global/dotnet.instructions.md
+++ b/ai/global/dotnet.instructions.md
@@ -81,8 +81,9 @@ dotnet reportgenerator \
 
 The per-assembly reports remain the authoritative measure of test quality for each project.
 
-### Specifics Coverage rules (MANDATGORY)
-* If a source generator is used then its because we _WANT_ the source generated version. Don't turn it off to get 100% code coverage
+### Specific Coverage Rules (MANDATORY)
+
+- If a source generator is used then it is because we _WANT_ the source generated version. Don't turn it off to get 100% code coverage.
 
 ## Source-Generated Logging
 

--- a/ai/global/git.examples.md
+++ b/ai/global/git.examples.md
@@ -9,6 +9,8 @@ Run before any commit to verify identity and GPG signing:
 ```bash
 #!/bin/sh
 # Checks that git is configured with a valid identity and GPG signing.
+# The die() and info() helpers below mirror the canonical implementations in
+# shell-scripts.examples.md — keep them in sync if either changes.
 
 die() {
     printf '\n\033[31m✗\033[0m %s\n' "$*"

--- a/ai/global/git.examples.md
+++ b/ai/global/git.examples.md
@@ -13,7 +13,7 @@ Run before any commit to verify identity and GPG signing:
 # shell-scripts.examples.md — keep them in sync if either changes.
 
 die() {
-    printf '\n\033[31m✗\033[0m %s\n' "$*"
+    printf '\n\033[31m✗\033[0m %s\n' "$*" >&2
     exit 1
 }
 

--- a/ai/global/git.instructions.md
+++ b/ai/global/git.instructions.md
@@ -6,14 +6,6 @@
 
 Verify all required languages and runtimes are installed. If any are missing, stop — do not scaffold code or make partial changes; ask the user to install them first.
 
-## Missing CLI Tools (MANDATORY)
-
-If a required CLI tool is not found, **stop immediately and ask the user to install it**. Never:
-
-- Search for the binary in alternative locations
-- Manipulate PATH to try to find it
-- Attempt to install it without being asked
-
 ## Environment Health (MANDATORY)
 
 If the environment is too broken to work in without first fixing infrastructure or tooling, **stop** and demand it be fixed. Do not work around broken tooling.

--- a/ai/global/index.md
+++ b/ai/global/index.md
@@ -4,7 +4,7 @@ This is an index of global instructions that apply to all projects.
 
 - Ensure consistency across all projects.
 - This folder should be maintained ONLY in the `git@github.com:credfeto/cs-template.git` repository.
-- Updates to this folder will be distributed using an external mechanism. A secondary authoritative template (`credfeto/funfair-server-template`) also distributes from this folder — raise instruction changes in either template repo as appropriate.
+- Updates to this folder will be distributed using an external mechanism. A secondary authoritative template (`funfair-tech/funfair-server-template`) also distributes from this folder — raise instruction changes in either template repo as appropriate.
 - Rule files are named `<category>.instructions.md`; code reference files are named `<category>.examples.md`.
 - All files must maintain a backlink to this index.
 - When adding a rule, check all other files for conflicts or duplication.

--- a/ai/global/index.md
+++ b/ai/global/index.md
@@ -4,7 +4,7 @@ This is an index of global instructions that apply to all projects.
 
 - Ensure consistency across all projects.
 - This folder should be maintained ONLY in the `git@github.com:credfeto/cs-template.git` repository.
-- Updates to this folder will be distributed using an external mechanism.
+- Updates to this folder will be distributed using an external mechanism. A secondary authoritative template (`credfeto/funfair-server-template`) also distributes from this folder — raise instruction changes in either template repo as appropriate.
 - Rule files are named `<category>.instructions.md`; code reference files are named `<category>.examples.md`.
 - All files must maintain a backlink to this index.
 - When adding a rule, check all other files for conflicts or duplication.

--- a/ai/global/index.md
+++ b/ai/global/index.md
@@ -3,8 +3,7 @@
 This is an index of global instructions that apply to all projects.
 
 - Ensure consistency across all projects.
-- This folder should be maintained ONLY in the `git@github.com:credfeto/cs-template.git` repository.
-- Updates to this folder will be distributed using an external mechanism. A secondary authoritative template (`funfair-tech/funfair-server-template`) also distributes from this folder — raise instruction changes in either template repo as appropriate.
+- `credfeto/cs-template` is the canonical source for this folder; all edits must originate here and are distributed to other repositories (including `funfair-tech/funfair-server-template`) via an external sync mechanism.
 - Rule files are named `<category>.instructions.md`; code reference files are named `<category>.examples.md`.
 - All files must maintain a backlink to this index.
 - When adding a rule, check all other files for conflicts or duplication.

--- a/ai/global/logging.instructions.md
+++ b/ai/global/logging.instructions.md
@@ -1,7 +1,5 @@
 # Logging Instructions
 
-> Load when: writing code that produces log output.
-
 [Back to Global Instructions Index](index.md)
 
 ## Rules

--- a/ai/global/packages.instructions.md
+++ b/ai/global/packages.instructions.md
@@ -1,7 +1,5 @@
 # Package Management Instructions
 
-> Load when: adding, updating, or reviewing package/library dependencies.
-
 [Back to Global Instructions Index](index.md)
 
 - Use only secure package versions — see [security.instructions.md](security.instructions.md#dependency-vulnerability-scanning).

--- a/ai/global/shell-scripts.examples.md
+++ b/ai/global/shell-scripts.examples.md
@@ -1,6 +1,6 @@
 # Shell Script Examples
 
-[Back to Global Instructions Index](index.md)
+[Back to Shell Script Instructions](shell-scripts.instructions.md) | [Back to Global Instructions Index](index.md)
 
 Reference implementations for the helper functions described in [shell-scripts.instructions.md](shell-scripts.instructions.md). Load this file when actively writing or modifying shell scripts.
 

--- a/ai/global/shell.firewall.examples.md
+++ b/ai/global/shell.firewall.examples.md
@@ -1,6 +1,6 @@
 # Firewall Script Examples
 
-[Back to Global Instructions Index](index.md)
+[Back to Shell Firewall Instructions](shell.firewall.instructions.md) | [Back to Global Instructions Index](index.md)
 
 Reference implementations for the firewall helpers described in [shell.firewall.instructions.md](shell.firewall.instructions.md). Load this file when actively writing or modifying firewall scripts.
 

--- a/ai/global/sql.examples.md
+++ b/ai/global/sql.examples.md
@@ -1,6 +1,6 @@
 # SQL Examples
 
-[Back to Global Instructions Index](index.md)
+[Back to SQL Instructions](sql.instructions.md) | [Back to Global Instructions Index](index.md)
 
 Reference examples for [sql.instructions.md](sql.instructions.md). Load when writing or debugging SQL, database connection scripts, or stored procedures.
 

--- a/ai/global/task-workflow.instructions.md
+++ b/ai/global/task-workflow.instructions.md
@@ -46,6 +46,14 @@ When creating or updating a PR linked to one or more issues:
 
 Repeat after every push or PR update.
 
+## Missing CLI Tools (MANDATORY)
+
+If a required CLI tool is not found, **stop immediately and ask the user to install it**. Never:
+
+- Search for the binary in alternative locations
+- Manipulate PATH to try to find it
+- Attempt to install it without being asked
+
 ## Rules Compliance for In-Flight Work
 
 Whenever an instruction file is added or updated, re-evaluate all open branches and PRs against the new rules. Fix any non-compliance before continuing — treat it the same as a CI failure.

--- a/ai/global/task-workflow.instructions.md
+++ b/ai/global/task-workflow.instructions.md
@@ -52,7 +52,8 @@ Whenever an instruction file is added or updated, re-evaluate all open branches 
 
 ## Instruction File Source Routing
 
-- If the file originates from `funfair-tech/funfair-server-template` or `credfeto/cs-template`, raise an issue there first. Both are authoritative template repositories — `credfeto/cs-template` for C# projects, `credfeto/funfair-server-template` for FunFair server projects.
+- For changes to shared global instruction files (`ai/global/**`), raise an issue in `credfeto/cs-template` — it is the canonical source for those files.
+- For changes specific to FunFair server projects, raise an issue in `funfair-tech/funfair-server-template` instead.
 - Otherwise, make the change directly in the current repository.
 
 ## Large Multi-Handler / Multi-App Tasks

--- a/ai/global/task-workflow.instructions.md
+++ b/ai/global/task-workflow.instructions.md
@@ -52,7 +52,7 @@ Whenever an instruction file is added or updated, re-evaluate all open branches 
 
 ## Instruction File Source Routing
 
-- If the file originates from `credfeto/funfair-server-template` or `credfeto/cs-template`, raise an issue there first. Both are authoritative template repositories — `credfeto/cs-template` for C# projects, `credfeto/funfair-server-template` for FunFair server projects.
+- If the file originates from `funfair-tech/funfair-server-template` or `credfeto/cs-template`, raise an issue there first. Both are authoritative template repositories — `credfeto/cs-template` for C# projects, `credfeto/funfair-server-template` for FunFair server projects.
 - Otherwise, make the change directly in the current repository.
 
 ## Large Multi-Handler / Multi-App Tasks

--- a/ai/global/task-workflow.instructions.md
+++ b/ai/global/task-workflow.instructions.md
@@ -52,7 +52,7 @@ Whenever an instruction file is added or updated, re-evaluate all open branches 
 
 ## Instruction File Source Routing
 
-- If the file originates from `funfair/funfair-server-template` or `credfeto/cs-template`, raise an issue there first.
+- If the file originates from `credfeto/funfair-server-template` or `credfeto/cs-template`, raise an issue there first. Both are authoritative template repositories — `credfeto/cs-template` for C# projects, `credfeto/funfair-server-template` for FunFair server projects.
 - Otherwise, make the change directly in the current repository.
 
 ## Large Multi-Handler / Multi-App Tasks


### PR DESCRIPTION
Fixes all applicable findings from credfeto/credfeto-docker-http-healthcheck-client#33 (excluding `ai/local/**/*` as instructed).

## Changes

### Typos & Grammar
- `dotnet.instructions.md`: `MANDATGORY` → `MANDATORY`, `Specifics Coverage rules` → `Specific Coverage Rules`; also fix list style (asterisk → dash) and blank lines

### Stale Reference
- `task-workflow.instructions.md`: correct `funfair/funfair-server-template` → `credfeto/funfair-server-template`
- `index.md`: add note documenting `credfeto/funfair-server-template` as a second authoritative template source

### Missing Backlinks
- `shell-scripts.examples.md`: add link back to `shell-scripts.instructions.md`
- `shell.firewall.examples.md`: add link back to `shell.firewall.instructions.md`
- `sql.examples.md`: add both backlinks matching the pattern from other examples files

### Always Load vs File Header Alignment
- Remove stale `> Load when:` directives from `logging.instructions.md`, `packages.instructions.md`, and `documentation.instructions.md` — all three are under **Always Load** in `index.md`

### Changelog Tool Clarification
- `changelog.instructions.md`: note that `Credfeto.Changelog.Cmd` is the dotnet tool package that provides the `dotnet changelog` command

### Duplicate Rule Reduction
- `.ai-instructions`: reduce the missing-CLI-tool rule to a pointer to the canonical MANDATORY section in `git.instructions.md`

### Cross-Reference
- `git.examples.md`: add comment noting the inline helpers mirror `shell-scripts.examples.md`

### Sub-Agent Scope Consistency
- `agent-roles.instructions.md`: make each sub-agent scope line neutral — caller supplies the scope (newly changed for Code Reviewer; full file set for Repo Auditor)

### Rule Category Correction
- Move **Rule Breaking** from Correctness to Compliance categories in `agent-roles.instructions.md`

### PR Submitter Clarification
- Remove the inline `git rebase` from PR Submitter — rebasing is Rebase Agent's responsibility