### PR TITLE
docs: add Blocked-label and comment-reply rules to Orchestrator in agent-roles.instructions.md

### DIFF
--- a/ai/global/agent-roles.instructions.md
+++ b/ai/global/agent-roles.instructions.md
@@ -10,6 +10,23 @@ Load when acting as a named agent. Routing table and model selection: [task-work
 - Determine work type and route via the routing table. Never implement directly.
 - If a delegated role escalates a task as infeasible (Coding Researcher **Not possible** result), do not re-route it unchanged. Record the finding on the issue/PR and surface it to the user for a decision — re-scope, accept the suggested alternative, or drop.
 
+### Blocked Label
+
+When asking a question in a PR or issue comment and waiting for an answer before continuing:
+
+1. Add the `Blocked` label to the PR or issue immediately after posting the question:
+   - Issue: `gh issue edit <number> --repo <owner/repo> --add-label "Blocked"`
+   - PR: `gh pr edit <number> --repo <owner/repo> --add-label "Blocked"`
+2. Do **not** continue working on the item until the label is removed.
+
+### Comment Replies (MANDATORY)
+
+Reply to every PR or issue comment that prompted an action:
+
+- Code change made: reply with `Fixed in <commit-sha> — <one sentence describing what changed and why>`.
+- Question answered inline (no code change): reply with the full answer.
+- No reply means no acknowledgement — always close the loop.
+
 ## Coding Researcher
 
 Invoked by: Code Writer, Code Fixer, Code Reviewer, CI Debugger.

--- a/ai/global/agent-roles.instructions.md
+++ b/ai/global/agent-roles.instructions.md
@@ -192,7 +192,7 @@ Invoked by: Code Writer, Code Fixer, Code Reviewer, CI Debugger.
 - Convert to draft before starting (`gh pr ready <number> --undo`).
 - One commit per review comment. Hand off to Code Tester after each fix.
 - Respond to **every** review comment without exception:
-  - If the comment required a code change: reply with `Fixed in <commit-sha>`.
+  - If the comment required a code change: reply with `Fixed in <commit-sha> — <one sentence describing what changed and why>`.
   - If the comment is a question or discussion point (no code change needed): reply with a full answer inline on the PR.
 
 ## Rebase Agent


### PR DESCRIPTION
## Summary

- Adds **Blocked Label** rule: when the Orchestrator posts a question and must wait for an answer, it must immediately add the `Blocked` label to the PR or issue and not continue until the label is removed.
- Adds **Comment Replies (MANDATORY)** rule: the Orchestrator must reply to every PR or issue comment that prompted an action — either with a commit reference for code changes, or a full inline answer for discussion points.

Both rules were previously captured as local instructions in `credfeto/credfeto-orchestrator` but apply universally to the Orchestrator role across all repositories.

Closes #820

## Test plan

- [ ] Verify the two new subsections appear under the `## Orchestrator` heading in `ai/global/agent-roles.instructions.md`
- [ ] Confirm the rule text matches the proposed text in issue #820
- [ ] Verify markdownlint passes (confirmed by pre-commit hook)