### PR TITLE
feat: add GitHub CLI comment body, label management, and CI check-once rules

### DIFF
--- a/ai/global/agent-roles.instructions.md
+++ b/ai/global/agent-roles.instructions.md
@@ -33,6 +33,21 @@ Reply to every PR or issue comment that prompted an action:
 - Question answered inline (no code change): reply with the full answer.
 - No reply means no acknowledgement — always close the loop.
 
+### CI Checks (MANDATORY)
+
+When working on a PR, check CI state **once**:
+
+```bash
+gh pr checks <number> --repo <owner/repo>
+```
+
+Then act immediately — do **not** loop, sleep, or use `--watch`:
+
+- All required checks passed → proceed with the next step.
+- Any check pending or in_progress → post a brief status comment on the PR and stop. The orchestrator re-invokes the session automatically when the PR state changes (checks complete, review arrives, etc.).
+- Any check failed → investigate, fix, push, post a status comment, and stop. Do not wait for the new run to complete.
+- CI consistently failing and cannot be fixed → mark the PR blocked: `gh pr edit <number> --repo <owner/repo> --add-label Blocked`
+
 ## Coding Researcher
 
 Invoked by: Code Writer, Code Fixer, Code Reviewer, CI Debugger.

--- a/ai/global/agent-roles.instructions.md
+++ b/ai/global/agent-roles.instructions.md
@@ -46,7 +46,7 @@ Then act immediately — do **not** loop, sleep, or use `--watch`:
 - All required checks passed → proceed with the next step.
 - Any check pending or in_progress → post a brief status comment on the PR and stop. The orchestrator re-invokes the session automatically when the PR state changes (checks complete, review arrives, etc.).
 - Any check failed → investigate, fix, push, post a status comment, and stop. Do not wait for the new run to complete.
-- CI consistently failing and cannot be fixed → mark the PR blocked: `gh pr edit <number> --repo <owner/repo> --add-label Blocked`
+- CI consistently failing and cannot be fixed → mark the PR blocked: `gh pr edit <number> --repo <owner/repo> --add-label "Blocked"`
 
 ## Coding Researcher
 

--- a/ai/global/git.instructions.md
+++ b/ai/global/git.instructions.md
@@ -26,6 +26,21 @@ Before any commit, verify identity and GPG signing are correct — see [git.exam
 - Never commit if the current branch is `main`.
 - If the branch has switched to `main` and the upstream no longer exists (merged and deleted), create a new branch before continuing.
 
+## GitHub CLI Comment Bodies (MANDATORY)
+
+When posting comment or PR bodies via the GitHub CLI (`gh issue comment`, `gh pr comment`, `gh pr create`, `gh pr edit`, etc.), always pass multi-line text using a HEREDOC so that real newline characters are embedded. **Never** use escaped `\n` sequences — GitHub renders them as literal characters, not line breaks:
+
+```bash
+gh issue comment <number> --repo <owner/repo> --body "$(cat <<'COMMENT'
+First paragraph.
+
+Second paragraph.
+COMMENT
+)"
+```
+
+This applies to any `--body` argument that contains or may contain newlines.
+
 ## GitHub Issues
 
 - If `gh` is available, use it to manage issues for every piece of work.

--- a/ai/global/task-workflow.instructions.md
+++ b/ai/global/task-workflow.instructions.md
@@ -69,6 +69,11 @@ When creating or updating a PR linked to one or more issues:
 
 Repeat after every push or PR update.
 
+## Label Management (MANDATORY)
+
+- Always use `--add-label` when adding labels — **never** `--label`, which replaces all existing labels and destroys automatically-applied classification labels.
+- Never remove labels from issues or PRs. GitHub workflows add classification labels automatically; removing them breaks automation.
+
 ## Missing CLI Tools (MANDATORY)
 
 If a required CLI tool is not found, **stop immediately and ask the user to install it**. Never:


### PR DESCRIPTION
Moves three rules out of the oneshot bootstrap prompts and into the global instruction files so they are loaded automatically by every Claude session without bloating prompts.

- **git.instructions.md**: HEREDOC rule for `gh` comment bodies — never escaped `\n`
- **task-workflow.instructions.md**: Label management — always `--add-label`, never `--label`, never remove labels
- **agent-roles.instructions.md**: CI check-once policy under Orchestrator — check once, act immediately, never poll or `--watch`

Companion PR in credfeto-orchestrator removes the inline IMPORTANT blocks from `build_issue_prompt` and `build_pr_prompt` and replaces them with a one-line reminder to follow the AI instructions.