### PR TITLE
fix: use %5C to percent-encode backslashes in GenerateCoverageSettings so regex dots survive MSBuild path normalisation on Linux

### DIFF
--- a/src/UnitTests.props
+++ b/src/UnitTests.props
@@ -35,7 +35,7 @@
 
     <Target Name="GenerateCoverageSettings" BeforeTargets="Build">
         <ItemGroup>
-            <!-- %3F = ?, %2A = * : percent-encode glob chars so MSBuild does not expand these items as filesystem globs -->
+            <!-- %3F = ?, %2A = *, %5C = \ : percent-encode special chars so MSBuild does not expand globs or normalise backslashes to / on Linux -->
             <_CoverageSettingsLines Include="&lt;Configuration&gt;" />
             <_CoverageSettingsLines Include="  &lt;CodeCoverage&gt;" />
             <_CoverageSettingsLines Include="    &lt;ModulePaths&gt;" />
@@ -45,7 +45,7 @@
             <_CoverageSettingsLines Include="    &lt;/ModulePaths&gt;" />
             <_CoverageSettingsLines Include="    &lt;Attributes&gt;" />
             <_CoverageSettingsLines Include="      &lt;Exclude&gt;" />
-            <_CoverageSettingsLines Include="        &lt;Attribute&gt;^System\.CodeDom\.Compiler\.GeneratedCodeAttribute$&lt;/Attribute&gt;" />
+            <_CoverageSettingsLines Include="        &lt;Attribute&gt;^System%5C.CodeDom%5C.Compiler%5C.GeneratedCodeAttribute$&lt;/Attribute&gt;" />
             <_CoverageSettingsLines Include="      &lt;/Exclude&gt;" />
             <_CoverageSettingsLines Include="    &lt;/Attributes&gt;" />
             <_CoverageSettingsLines Include="  &lt;/CodeCoverage&gt;" />


### PR DESCRIPTION
## Summary

- In `src/UnitTests.props`, the `GenerateCoverageSettings` target builds coverage XML via `<_CoverageSettingsLines Include="...">` items.
- MSBuild normalises backslashes to forward slashes on Linux when processing `Include` values, turning `\.` into `/` in the emitted file.
- The attribute exclusion regex `^System\.CodeDom\.Compiler\.GeneratedCodeAttribute$` became `^System/.CodeDom/.Compiler/.GeneratedCodeAttribute$` and never matched, causing source-generated types decorated with `[GeneratedCode]` (e.g. `[LoggerMessage]` classes) to be counted in coverage instead of excluded.
- Fix: replace each `\.` with `%5C.` (URL-encoded backslash), consistent with the existing `%2A`/`%3F` encoding already used in the same target for `*` and `?`.
- Updated the comment above the item group to document the new encoding.

No CHANGELOG entry added — the changelog instructions exclude repos whose name contains `-template`.

Closes #830