### PR TITLE
fix: prohibit benchmark test runs and add Monitor tool poll guidance

### DIFF
--- a/ai/global/dotnet.instructions.md
+++ b/ai/global/dotnet.instructions.md
@@ -45,6 +45,7 @@ A project is a test project **only** if its assembly name ends with one of these
 **Rules that must never be broken:**
 
 - **Never** use "contains 'Test'" in a project name as a heuristic — a project named `*.TestHarness`, `*.Tests.Mocks`, or `*.Tests.Common` is NOT a test project.
+- **Never** run `dotnet test` or `dotnet run` on `*.Benchmark.Tests` projects — BenchmarkDotNet performs real measurements that take hours and spawn dozens of build processes. CI handles benchmarks; never run them manually.
 - **Never** target a project with `dotnet test` if its csproj contains `<IsTestProject>false</IsTestProject>` or `<IsTestingPlatformApplication>false</IsTestingPlatformApplication>`.
 - **Do not** rely on `OutputType` or the project SDK as a discriminator — with Microsoft.Testing.Platform, legitimate test projects also use `OutputType=Exe`, and some test projects use `Microsoft.NET.Sdk.Web`.
 - **Always** verify `IsTestingPlatformApplication` in the csproj — this is the property `dotnet test` in .NET 10 uses for discovery, not `IsTestProject`. The naming convention and `IsTestingPlatformApplication` are the only reliable signals.

--- a/ai/global/task-workflow.instructions.md
+++ b/ai/global/task-workflow.instructions.md
@@ -153,7 +153,15 @@ When using the Monitor tool to watch a background Bash task, the poll condition 
    done
    ```
 
-   If the deadline fires, report the failure — do not silently continue.
+   If the deadline fires, mark the work item Blocked and stop:
+
+   ```bash
+   gh issue edit <number> --repo <owner/repo> --add-label "Blocked"
+   gh issue comment <number> --repo <owner/repo> \
+       --body "Blocked: timed out after 30 minutes waiting for <what>. Last output: $(tail -5 "${output_file}" 2>/dev/null)"
+   ```
+
+   Use `gh pr edit` / `gh pr comment` instead if the work item is a PR. Then exit — do not continue work.
 
 ### Reliable poll strings by command
 

--- a/ai/global/task-workflow.instructions.md
+++ b/ai/global/task-workflow.instructions.md
@@ -140,6 +140,21 @@ When using the Monitor tool to watch a background Bash task, the poll condition 
 
 4. **Prefer foreground over background for bounded work.** Use `run_in_background: true` only when a command genuinely takes many minutes (e.g. a full integration-test run) and you have independent work to do while waiting. A `dotnet build` or `git commit` should always run in the foreground.
 
+5. **Time-box every poll loop — die after 30 minutes.** Always include a deadline so the session cannot hang forever:
+
+   ```bash
+   deadline=$(( $(date +%s) + 1800 ))
+   until grep -q "Build succeeded." "${output_file}" 2>/dev/null; do
+       sleep 15
+       if [ "$(date +%s)" -ge "${deadline}" ]; then
+           echo "ERROR: timed out after 30 minutes waiting for build" >&2
+           exit 1
+       fi
+   done
+   ```
+
+   If the deadline fires, report the failure — do not silently continue.
+
 ### Reliable poll strings by command
 
 | Command / scenario | String to poll for |

--- a/ai/global/task-workflow.instructions.md
+++ b/ai/global/task-workflow.instructions.md
@@ -126,6 +126,31 @@ For complex files, commit+push+update after each round — do not wait until ful
 
 > Pre-commit hooks may make commits slow — wait for them to complete before assuming failure.
 
+## Background Tasks and Monitor Tool (MANDATORY)
+
+When using the Monitor tool to watch a background Bash task, the poll condition in the `until` loop **must** be provably satisfiable — a condition that can never be met loops forever and blocks the entire session.
+
+### Rules for poll conditions
+
+1. **Never poll for `"exit code"`** — that string is not reliably written to background task output files. Poll for a specific string the command itself writes (see table below).
+
+2. **Do not pipe after `grep -q` in a negation check.** `! grep -q "pattern" file | tail -1` does NOT detect absence — the pipe applies to grep's (empty) stdout, so `tail -1` exits 0 regardless, and `!` inverts that to always-false. Write `! grep -q "pattern" file` with no trailing pipe.
+
+3. **Verify the poll string exists in real output before writing the loop.** If you cannot confirm what string the command writes, run the command in the foreground first and read its output.
+
+4. **Prefer foreground over background for bounded work.** Use `run_in_background: true` only when a command genuinely takes many minutes (e.g. a full integration-test run) and you have independent work to do while waiting. A `dotnet build` or `git commit` should always run in the foreground.
+
+### Reliable poll strings by command
+
+| Command / scenario | String to poll for |
+| --- | --- |
+| `dotnet build` succeeded | `Build succeeded.` |
+| `dotnet test` all passed | `Passed!` |
+| pre-commit hooks passed | `→ All checks passed.` |
+| pre-commit hooks failed | `→` followed by `Failed` (check for both to distinguish pass/fail) |
+| `git push` completed | `branch` (branch tracking line in push output) |
+| `gh pr create` / `gh pr ready` | poll not needed — these exit immediately |
+
 ## Multi-Agent Implementation and Review Pattern
 
 ### Model Selection


### PR DESCRIPTION
## Summary

- **`dotnet.instructions.md`**: Explicitly prohibit running `dotnet test` or `dotnet run` on `*.Benchmark.Tests` projects. BenchmarkDotNet performs real measurements that take hours and spawn dozens of parallel build processes per job — CI handles benchmarks, never run them manually.

- **`task-workflow.instructions.md`**: Add a \"Background Tasks and Monitor Tool\" section covering the three failure modes observed in production sessions:
  1. Polling for `"exit code"` — not reliably written to background task output files
  2. `! grep -q "pattern" file | tail -1` — pipe-precedence bug; `tail -1` on grep's empty `-q` stdout exits 0, so `!` inverts to always-false
  3. Using unverified poll strings — conditions that can never be satisfied loop forever and block the session

Includes a table of reliable poll strings for common commands (dotnet build, dotnet test, pre-commit hooks, git push).

## Test plan

- [ ] Review instruction text is unambiguous and actionable
- [ ] No formatting issues in rendered markdown