### PR TITLE
docs: add detailed README.md guidelines with badge, structure, and examples guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,35 @@
 # cs-template
-C# Template
+
+Canonical source for shared AI instruction files, GitHub workflow templates, and project configuration for C# projects.
 
 ## Build Status
 
-| Branch  | Status                                                                                                                                                                                                                                |
-|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| main    | [![Build: Pre-Release](https://github.com/credfeto/cs-template/actions/workflows/build-and-publish-pre-release.yml/badge.svg)](https://github.com/credfeto/cs-template/actions/workflows/build-and-publish-pre-release.yml) |
-| release | [![Build: Release](https://github.com/credfeto/cs-template/actions/workflows/build-and-publish-release.yml/badge.svg)](https://github.com/credfeto/cs-template/actions/workflows/build-and-publish-release.yml)             |
+| Branch  | Status                                                |
+|---------|-------------------------------------------------------|
+| main    | [![Build: Pre-Release][pre-release-img]][pre-release] |
+| release | [![Build: Release][release-img]][release]             |
 
 ## Changelog
 
-View [changelog](CHANGELOG.md)
+View [changelog][changelog].
 
-## Contributors
+## Contributing
 
-<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-<!-- prettier-ignore-start -->
-<!-- markdownlint-disable -->
+See [contributing guidelines][contributing].
 
-<!-- markdownlint-restore -->
-<!-- prettier-ignore-end -->
+## Security
 
-<!-- ALL-CONTRIBUTORS-LIST:END -->
+See [security policy][security].
+
+## Licence
+
+This project is licensed under the [MIT Licence][licence].
+
+[changelog]: CHANGELOG.md
+[contributing]: CONTRIBUTING.md
+[licence]: LICENSE
+[pre-release-img]: https://github.com/credfeto/cs-template/actions/workflows/build-and-publish-pre-release.yml/badge.svg
+[pre-release]: https://github.com/credfeto/cs-template/actions/workflows/build-and-publish-pre-release.yml
+[release-img]: https://github.com/credfeto/cs-template/actions/workflows/build-and-publish-release.yml/badge.svg
+[release]: https://github.com/credfeto/cs-template/actions/workflows/build-and-publish-release.yml
+[security]: SECURITY.md

--- a/ai/global/documentation.instructions.md
+++ b/ai/global/documentation.instructions.md
@@ -21,7 +21,7 @@
 9. **Contributing** — link to `CONTRIBUTING.md`.
 10. **Security** — link to `SECURITY.md`.
 11. **Licence** — link to `LICENSE`.
-12. **Contributors** — all-contributors section (keep the auto-generated markers in place).
+12. **Contributors** — all-contributors section; see the [Contributors section](#contributors) below for when to include it.
 
 Omit any section that does not apply (e.g. no Installation section for a library with no NuGet package), but never invent placeholder sections.
 
@@ -72,3 +72,23 @@ Only include badges that are actively maintained and reflect real state. Remove 
 - All non-template repos must have a `docs/` folder; template repos must not.
 - Place all docs and architecture diagrams (except `README.md`/`CHANGELOG.md`) in `docs/`; keep them current.
 - Architecture diagrams: show folder structure only — omit individual files and package versions; prefer SVG over raster formats.
+
+## Contributors
+
+- Include a `## Contributors` section in `README.md` using the [all-contributors](https://allcontributors.org) spec **only when the repository has more than one known human contributor**. Omit the section entirely when there is only one.
+- When the condition is met, preserve the auto-generated comment markers exactly — do not reformat, reorder, or remove them:
+
+```markdown
+## Contributors
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+```
+
+- Never manually edit the content between the `START` and `END` markers — the all-contributors bot manages that block.

--- a/ai/global/documentation.instructions.md
+++ b/ai/global/documentation.instructions.md
@@ -5,12 +5,70 @@
 ## README
 
 - Keep `README.md` accurate and up to date; rewrite template placeholder content before starting work.
-- Include where applicable: CI badges (debug + release), links to `docs/`, build instructions, `CONTRIBUTING.md`, `SECURITY.md`, `CHANGELOG.md`.
 - Update the configuration section in the same commit whenever a config option (`appsettings.json`, options class, or env var) is added, removed, or renamed — include type, default, and description.
 - For changelog format and tooling see [changelog.instructions.md](changelog.instructions.md).
 
+### Required Sections (in this order)
+
+1. **Title and one-line description** — state what the project does, not just what it is named.
+2. **Badges** — see [Badge Guidelines](#badge-guidelines) below.
+3. **Overview** — 2–3 sentences explaining the purpose and key features.
+4. **Quick Start / Simple Example** — the minimal copy-paste snippet that gets something working; no preamble.
+5. **Installation** — e.g. `dotnet add package <Name>` or the NuGet Package Manager command.
+6. **Usage / Examples** — one or two brief, self-contained examples; link to `docs/` for more complex ones.
+7. **Documentation** — link to the `docs/` folder and any generated API documentation (e.g. DocFX, Doxygen, GitHub Pages).
+8. **Changelog** — link to `CHANGELOG.md`.
+9. **Contributing** — link to `CONTRIBUTING.md`.
+10. **Security** — link to `SECURITY.md`.
+11. **Licence** — link to `LICENSE`.
+12. **Contributors** — all-contributors section (keep the auto-generated markers in place).
+
+Omit any section that does not apply (e.g. no Installation section for a library with no NuGet package), but never invent placeholder sections.
+
+### Badge Guidelines
+
+Place all badges near the top of the file, after the title but before the overview prose.
+
+#### CI / Build Status
+
+Use a table to separate `main`/pre-release from `release` builds:
+
+```markdown
+| Branch  | Status |
+|---------|--------|
+| main    | [![Build: Pre-Release](https://github.com/OWNER/REPO/actions/workflows/build-and-publish-pre-release.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/build-and-publish-pre-release.yml) |
+| release | [![Build: Release](https://github.com/OWNER/REPO/actions/workflows/build-and-publish-release.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/build-and-publish-release.yml) |
+```
+
+#### NuGet (when the project publishes a package)
+
+```markdown
+[![NuGet](https://img.shields.io/nuget/v/PACKAGE_NAME.svg)](https://www.nuget.org/packages/PACKAGE_NAME)
+[![NuGet Downloads](https://img.shields.io/nuget/dt/PACKAGE_NAME.svg)](https://www.nuget.org/packages/PACKAGE_NAME)
+```
+
+#### Code Coverage
+
+```markdown
+[![codecov](https://codecov.io/gh/OWNER/REPO/branch/main/graph/badge.svg)](https://codecov.io/gh/OWNER/REPO)
+```
+
+#### Licence
+
+```markdown
+[![Licence](https://img.shields.io/github/license/OWNER/REPO)](LICENSE)
+```
+
+#### Open Issues / Bugs
+
+```markdown
+[![Bugs](https://img.shields.io/github/issues/OWNER/REPO/bug)](https://github.com/OWNER/REPO/issues?q=is%3Aopen+is%3Aissue+label%3Abug)
+```
+
+Only include badges that are actively maintained and reflect real state. Remove any badge whose target service is unavailable or whose data is stale.
+
 ## Additional Documentation
 
-- All repos except `credfeto/cs-template` must have a `docs/` folder; that repo must not.
+- All non-template repos must have a `docs/` folder; template repos must not.
 - Place all docs and architecture diagrams (except `README.md`/`CHANGELOG.md`) in `docs/`; keep them current.
 - Architecture diagrams: show folder structure only — omit individual files and package versions; prefer SVG over raster formats.

--- a/ai/global/documentation.instructions.md
+++ b/ai/global/documentation.instructions.md
@@ -22,7 +22,7 @@
 10. **Security** — link to `SECURITY.md`.
 11. **Licence** — link to `LICENSE`.
 12. **Contributors** — all-contributors section; see the [Contributors section](#contributors) below for when to include it.
-13. **Reference links** — all image and URL references used by badges and links, collected at the very bottom of the file.
+13. **Reference links** — all image and URL references used by badges and links, collected at the very bottom of the file, sorted alphabetically by label.
 
 Omit any section that does not apply (e.g. no Installation section for a library with no NuGet package), but never invent placeholder sections.
 
@@ -32,7 +32,7 @@ Place all badges near the top of the file, after the title but before the overvi
 
 #### Link Format (MANDATORY)
 
-All badges and hyperlinks must use **reference-style** markdown — never inline URLs. Use descriptive named labels; never use bare numbers (`[1]`, `[2]`). Collect all reference definitions at the very bottom of the file.
+All badges and hyperlinks must use **reference-style** markdown — never inline URLs. Use descriptive named labels; never use bare numbers (`[1]`, `[2]`). Collect all reference definitions at the very bottom of the file, sorted alphabetically by label.
 
 ```markdown
 [![Alt text][image-ref]][link-ref]

--- a/ai/global/documentation.instructions.md
+++ b/ai/global/documentation.instructions.md
@@ -22,6 +22,7 @@
 10. **Security** — link to `SECURITY.md`.
 11. **Licence** — link to `LICENSE`.
 12. **Contributors** — all-contributors section; see the [Contributors section](#contributors) below for when to include it.
+13. **Reference links** — all image and URL references used by badges and links, collected at the very bottom of the file.
 
 Omit any section that does not apply (e.g. no Installation section for a library with no NuGet package), but never invent placeholder sections.
 
@@ -29,40 +30,75 @@ Omit any section that does not apply (e.g. no Installation section for a library
 
 Place all badges near the top of the file, after the title but before the overview prose.
 
+#### Link Format (MANDATORY)
+
+All badges and hyperlinks must use **reference-style** markdown — never inline URLs. Use descriptive named labels; never use bare numbers (`[1]`, `[2]`). Collect all reference definitions at the very bottom of the file.
+
+```markdown
+[![Alt text][image-ref]][link-ref]
+
+<!-- bottom of file -->
+[image-ref]: https://example.com/badge.svg
+[link-ref]: https://example.com/
+```
+
 #### CI / Build Status
 
 Use a table to separate `main`/pre-release from `release` builds:
 
 ```markdown
-| Branch  | Status |
-|---------|--------|
-| main    | [![Build: Pre-Release](https://github.com/OWNER/REPO/actions/workflows/build-and-publish-pre-release.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/build-and-publish-pre-release.yml) |
-| release | [![Build: Release](https://github.com/OWNER/REPO/actions/workflows/build-and-publish-release.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/build-and-publish-release.yml) |
+| Branch  | Status                                            |
+|---------|---------------------------------------------------|
+| main    | [![Build: Pre-Release][pre-release-img]][pre-release] |
+| release | [![Build: Release][release-img]][release]         |
+
+<!-- bottom of file -->
+[pre-release-img]: https://github.com/OWNER/REPO/actions/workflows/build-and-publish-pre-release.yml/badge.svg
+[pre-release]: https://github.com/OWNER/REPO/actions/workflows/build-and-publish-pre-release.yml
+[release-img]: https://github.com/OWNER/REPO/actions/workflows/build-and-publish-release.yml/badge.svg
+[release]: https://github.com/OWNER/REPO/actions/workflows/build-and-publish-release.yml
 ```
 
 #### NuGet (when the project publishes a package)
 
 ```markdown
-[![NuGet](https://img.shields.io/nuget/v/PACKAGE_NAME.svg)](https://www.nuget.org/packages/PACKAGE_NAME)
-[![NuGet Downloads](https://img.shields.io/nuget/dt/PACKAGE_NAME.svg)](https://www.nuget.org/packages/PACKAGE_NAME)
+[![NuGet][nuget-img]][nuget]
+[![NuGet Downloads][nuget-downloads-img]][nuget]
+
+<!-- bottom of file -->
+[nuget-img]: https://img.shields.io/nuget/v/PACKAGE_NAME.svg
+[nuget-downloads-img]: https://img.shields.io/nuget/dt/PACKAGE_NAME.svg
+[nuget]: https://www.nuget.org/packages/PACKAGE_NAME
 ```
 
 #### Code Coverage
 
 ```markdown
-[![codecov](https://codecov.io/gh/OWNER/REPO/branch/main/graph/badge.svg)](https://codecov.io/gh/OWNER/REPO)
+[![codecov][codecov-img]][codecov]
+
+<!-- bottom of file -->
+[codecov-img]: https://codecov.io/gh/OWNER/REPO/branch/main/graph/badge.svg
+[codecov]: https://codecov.io/gh/OWNER/REPO
 ```
 
 #### Licence
 
 ```markdown
-[![Licence](https://img.shields.io/github/license/OWNER/REPO)](LICENSE)
+[![Licence][licence-img]][licence]
+
+<!-- bottom of file -->
+[licence-img]: https://img.shields.io/github/license/OWNER/REPO
+[licence]: LICENSE
 ```
 
 #### Open Issues / Bugs
 
 ```markdown
-[![Bugs](https://img.shields.io/github/issues/OWNER/REPO/bug)](https://github.com/OWNER/REPO/issues?q=is%3Aopen+is%3Aissue+label%3Abug)
+[![Bugs][bugs-img]][bugs]
+
+<!-- bottom of file -->
+[bugs-img]: https://img.shields.io/github/issues/OWNER/REPO/bug
+[bugs]: https://github.com/OWNER/REPO/issues?q=is%3Aopen+is%3Aissue+label%3Abug
 ```
 
 Only include badges that are actively maintained and reflect real state. Remove any badge whose target service is unavailable or whose data is stale.


### PR DESCRIPTION
## Summary

- Expands README guidelines in `ai/global/documentation.instructions.md` with a required section order (title, badges, overview, quick start, installation, usage/examples, docs, changelog, contributing, security, licence, contributors)
- Adds badge guidelines with copy-paste templates for CI build status (pre-release and release workflows), NuGet version and downloads, code coverage (codecov), licence, and open bugs
- Requires simple inline examples with links to `docs/` for more complete ones
- Removes the old single-line bullet that listed badge/link requirements without structure

Closes #903

## Test plan

- [ ] Review the updated `ai/global/documentation.instructions.md` for clarity and completeness
- [ ] Confirm badge markdown templates render correctly when substituted into a real README
- [ ] Verify markdownlint passes (covered by pre-commit hook in CI)