### PR TITLE
fix: require verbatim git command output in PR comments before any failure diagnosis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ## [Unreleased]
 ### Security
 ### Added
+- git.instructions: mandatory rule requiring verbatim command output in PR/issue comments before any diagnosis when a git command fails
 ### Fixed
 - on_new_pr.yml: inline composite action logic to fix local action path resolution failure under pull_request_target
 - Corrected plan-approval description: board Approved status or comment-based fallback (no board) are the explicit approval signals; orchestrator never auto-removes Blocked

--- a/ai/global/git.instructions.md
+++ b/ai/global/git.instructions.md
@@ -132,6 +132,24 @@ Rules:
 - Subsequent pushes on a tracked branch can use `git -C <repodir> push`.
 - **Never push without `-u` on the first push** — without it the branch has no upstream and later `git push` and `git pull` commands will fail.
 
+## Command Failure Reporting (MANDATORY)
+
+When any git command fails (push, rebase, fetch, etc.), you **must** quote the exact stdout and stderr output verbatim in any issue or PR comment before posting any explanation or diagnosis. Never substitute a narrative about why a command might have failed for the actual error output.
+
+Capture the output into a variable and embed it in the comment body:
+
+```bash
+push_output=$(git -C /path push --force-with-lease 2>&1) || true
+gh pr comment NUMBER --repo OWNER/REPO --body "$(cat <<COMMENT
+git push failed with:
+
+${push_output}
+COMMENT
+)"
+```
+
+This rule exists because AI-generated diagnoses of command failures are frequently wrong. The verbatim output is always correct; the explanation is not.
+
 ## Branch Naming
 
 Format: `<type>/<name>` (mirroring Conventional Commits types):


### PR DESCRIPTION
## Summary

- Adds a mandatory **Command Failure Reporting** rule to `git.instructions.md`
- When any git command (push, rebase, fetch, etc.) fails, the agent must quote exact stdout/stderr verbatim in the PR/issue comment before posting any explanation
- Includes a shell snippet showing how to capture and embed the output

## Motivation

Observed in funfair-tech/BuildBot#378: the agent posted a detailed narrative claiming SSH keys were missing and push was impossible via SSH — but SSH was working fine and pushing successfully for other repos in the same session. The agent fabricated a plausible-sounding diagnosis instead of reporting the actual error output.

The verbatim output is always correct; AI-generated diagnoses of command failures are not.