### PR TITLE
docs: update CI Checks rule to stop silently when checks are pending or in progress

### DIFF
--- a/ai/global/agent-roles.instructions.md
+++ b/ai/global/agent-roles.instructions.md
@@ -159,6 +159,8 @@ Reply to every PR or issue comment that prompted an action:
 
 ### CI Checks (MANDATORY)
 
+The `oneshot` pre-agentic gate (from `credfeto/credfeto-orchestrator`) normally blocks agent invocation while CI checks are pending, so the agent is rarely invoked with pending checks. The rules below act as a safety net for edge cases.
+
 When working on a PR, check CI state **once**:
 
 ```bash
@@ -168,7 +170,7 @@ gh pr checks <number> --repo <owner/repo>
 Then act immediately — do **not** loop, sleep, or use `--watch`:
 
 - All required checks passed → proceed with the next step.
-- Any check pending or in_progress → post a brief status comment on the PR and stop. The orchestrator re-invokes the session automatically when the PR state changes (checks complete, review arrives, etc.).
+- Any check pending or in_progress → stop silently — do not post a status comment. CI checks are bound by GitHub's own timeouts and will eventually pass, fail, or time out without agent intervention.
 - Any check failed → investigate, fix, push, post a status comment, and stop. Do not wait for the new run to complete.
 - CI consistently failing and cannot be fixed → mark the PR blocked: `gh pr edit <number> --repo <owner/repo> --add-label "Blocked"`
 


### PR DESCRIPTION
## Summary

Updates the `### CI Checks (MANDATORY)` section in `ai/global/agent-roles.instructions.md`:

- **Pending/in_progress behaviour**: Changed from "post a brief status comment and stop" to "stop silently — do not post a status comment". CI checks are bound by GitHub's own timeouts and will eventually pass, fail, or time out without agent intervention.
- **Context note added**: Explains that the `oneshot` pre-agentic gate (`credfeto/credfeto-orchestrator`) normally prevents agent invocation while CI is pending, so encountering pending checks is a rare edge case.

The failed-check and consistently-failing-CI behaviours are unchanged.

Closes #921