### PR TITLE
feat: add Environment/Infrastructure Block Marker convention for agents (credfeto/credfeto-orchestrator#1118)

### DIFF
--- a/ai/global/agent-roles.instructions.md
+++ b/ai/global/agent-roles.instructions.md
@@ -149,6 +149,23 @@ When asking a question in a PR or issue comment and waiting for an answer before
 2. Do **not** continue working on the item until the label is removed.
 3. Use **only** the `Blocked` label for this purpose — do **not** use labels like `do not merge`, `needs review`, or any other substitute. The orchestrator only recognises `Blocked` when deciding whether to skip an item.
 
+### Environment/Infrastructure Block Marker (MANDATORY, PRs only)
+
+When a Blocked-ing failure is diagnosed as an environment/infrastructure problem — a bug in the container image, a missing tool, a transient infra issue — rather than a bug in the PR's own code, add a machine-readable marker alongside the diagnosis so `oneshot` can auto-clear `Blocked` once the fix has actually shipped, instead of the PR sitting blocked until a human happens to notice (credfeto/credfeto-orchestrator#1118):
+
+1. Post the full human-readable diagnosis as normal — root cause, evidence, and (if known) the fix needed.
+2. Append a single trailer line to that same comment:
+
+   ```text
+   <!-- orchestrator:env-block image-sha=${IMAGE_SHA_DEVELOPMENT_AGENT} -->
+   ```
+
+   Read `IMAGE_SHA_DEVELOPMENT_AGENT` from your own container environment (the same value printed at session start as part of "Image layer provenance") — this records which image build was current when you made the diagnosis.
+3. Apply `Blocked` exactly as in the section above.
+4. Use this marker **only** for a genuine environment/infrastructure diagnosis. `oneshot` auto-clears `Blocked` the moment it observes a differently-built agent image, with no further human involvement — marking a real code question or design decision this way would resume work before a human actually answered it.
+
+This convention only applies to PRs (there is no container session, and therefore no image to diagnose against, before a PR/branch exists). Everything else about the Blocked-label convention above is unchanged.
+
 ### Comment Replies (MANDATORY)
 
 Reply to every PR or issue comment that prompted an action:
@@ -353,7 +370,7 @@ Invoked by: Code Writer, Code Fixer, Code Reviewer, CI Debugger.
 ## CI Debugger
 
 - Read full logs (`gh run view --log-failed`), identify root cause.
-- Fix if code-related; escalate to Orchestrator with a clear description if environmental or infrastructure.
+- Fix if code-related; escalate to Orchestrator with a clear description if environmental or infrastructure — use the Environment/Infrastructure Block Marker convention above so the block can auto-clear once the fix ships.
 - If a code-related fix requires knowledge outside the instruction files, invoke Coding Researcher first — do not guess or fabricate. If Coding Researcher returns **Not possible**, escalate to Orchestrator with the explanation.
 
 ## Changelog


### PR DESCRIPTION
## Summary

- Companion to credfeto/credfeto-orchestrator#1119 (fixes credfeto/credfeto-orchestrator#1118).
- `oneshot` in `credfeto-orchestrator` now auto-clears a PR's `Blocked` label once a newer agent container image has been built, but only for blocks the agent itself diagnosed as an environment/infrastructure failure. It needs a machine-readable signal to tell that apart from every other reason a PR gets blocked (a design question, an unresolved review, CI timeout).
- Adds a new "Environment/Infrastructure Block Marker" sub-section to `ai/global/agent-roles.instructions.md`'s Blocked Label conventions: when a failure is diagnosed as environmental, the agent appends `<!-- orchestrator:env-block image-sha=${IMAGE_SHA_DEVELOPMENT_AGENT} -->` to its diagnosis comment (using the SHA already present in its own container env) alongside the normal `Blocked` label.
- Points the existing CI Debugger role's "escalate to Orchestrator... if environmental or infrastructure" line at this new convention.
- `ai/global/` is template-managed, so this change belongs here rather than in `credfeto-orchestrator` directly.

## How Has This Been Tested

- [x] `markdownlint ai/global/agent-roles.instructions.md` — clean.
- [x] `dotnet buildcheck -solution src/Credfeto.Template.slnx` — no errors (unaffected, docs-only change).
- N/A: this repo has no `oneshot`/bats test suite of its own — the parsing/comparison logic is tested in credfeto/credfeto-orchestrator#1119.

## Types of changes

- [x] Docs change

## Checklist

- [x] No CHANGELOG entry — this repository is excluded per the changelog convention (`-template` repos are kept blank for template consumers).