### PR TITLE
docs: add MANDATORY rule against tool timeouts that truncate pre-commit/test commands (#942)

### DIFF
--- a/ai/global/index.md
+++ b/ai/global/index.md
@@ -15,7 +15,7 @@ Read all of these before starting any task, regardless of language or context.
 | File | Covers |
 | --- | --- |
 | [git.instructions.md](git.instructions.md) | Prerequisites, build/test verification, git identity/GPG, branching, version-conflict merge resolution, commits, GitHub issues |
-| [task-workflow.instructions.md](task-workflow.instructions.md) | Agent routing table, model selection, failure handling, issue/PR assignment, commit cadence, resuming work |
+| [task-workflow.instructions.md](task-workflow.instructions.md) | Agent routing table, model selection, failure handling, issue/PR assignment, commit cadence, resuming work, command timeouts |
 | [code-quality.instructions.md](code-quality.instructions.md) | Code coverage, tests, async, immutability, parameterised tests, refactoring |
 | [documentation.instructions.md](documentation.instructions.md) | README, CHANGELOG conventions |
 | [security.instructions.md](security.instructions.md) | No secrets in code, input validation, output sanitisation |

--- a/ai/global/task-workflow.instructions.md
+++ b/ai/global/task-workflow.instructions.md
@@ -199,6 +199,16 @@ When using the Monitor tool to watch a background Bash task, the poll condition 
 | `git push` completed | `branch` (branch tracking line in push output) |
 | `gh pr create` / `gh pr ready` | poll not needed — these exit immediately |
 
+## Never Truncate Test/Commit Commands (MANDATORY)
+
+This is a distinct concern from the poll-loop timeouts above: those govern how long you wait for something _else_ to finish; this governs the timeout on the command _actually doing the work_.
+
+Never pass a tool-level timeout that could truncate `pre-commit`, a `git commit` in a repo with pre-commit enabled (globally via `core.hooksPath` or locally via `.pre-commit-config.yaml`), `dotnet test`, `npm test`, or `bun test` — these must run to completion.
+
+- Pass the maximum available timeout rather than a short one (e.g. Claude Code's Bash tool supports up to 600000ms/10 minutes — use it, don't default to a shorter value).
+- If even the maximum available timeout is not enough, use `run_in_background` and the Monitor tool instead of accepting a truncated run.
+- A killed run does not just fail — it skips the target process's own cleanup (a bash `EXIT` trap, .NET's `IDisposable` teardown, etc.), leaving orphaned temp directories, lock files, or half-applied state behind. Confirmed in practice: a killed `bats` run left thousands of orphaned fixture directories under a shared runtime directory, which went on to break an unrelated tool (`firejail`) that walked the same path.
+
 ## Multi-Agent Implementation and Review Pattern
 
 ### Model Selection


### PR DESCRIPTION
## Description

A `git commit` running the full `bats` suite via a pre-commit hook was killed by the Bash tool's default 2-minute timeout mid-run (confirmed live in `credfeto-orchestrator`). The same mechanism plausibly explains a separate, larger incident the same day: thousands of orphaned `.NET` test fixture directories accumulated under a shared runtime directory from repeatedly hard-killed `dotnet test` runs, which went on to break an unrelated tool (`firejail`'s `ssh` profile) by making its directory processing take far longer than expected.

Adds a MANDATORY rule to `ai/global/task-workflow.instructions.md`: never pass a tool-level timeout that could truncate `pre-commit`, a `git commit` in a repo with pre-commit enabled, `dotnet test`, `npm test`, or `bun test` — use the maximum available timeout, or `run_in_background` + Monitor if even that isn't enough.

A companion change propagates the equivalent instruction into `credfeto-orchestrator`'s generated per-item `CLAUDE.md` (separate PR in that repo), since agents running inside that orchestrator's containers are a primary place this actually bites.

Closes #942

## How Has This Been Tested

- [x] All unit tests pass.
- [ ] All integration tests pass.
- [ ] Manual Testing: markdownlint/pre-commit pass on the edited files.

## Types of changes

- [x] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [ ] Additional Unit Tests\Integration Tests
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Removed no-longer used code

## Deployment Configuration Changes

- [ ] Requires deployment configuration changes as specified below and in CHANGELOG.md

## Checklist

- [x] I have added tests to cover my changes.
- [ ] Unreleased section of CHANGELOG.md has been updated with details of this PR.