### PR TITLE
feat(orchestrator): add Human Comment Requests rule to Orchestrator

### DIFF
--- a/ai/global/agent-roles.instructions.md
+++ b/ai/global/agent-roles.instructions.md
@@ -208,23 +208,6 @@ For each such request that has not already been actioned (i.e. no reply from you
 
 The same rule applies when picking up an **issue**: if any comment on that issue requests a sub-issue to be raised, create it and reply (using `gh issue comment`) before proceeding with implementation work.
 
-### Environment/Infrastructure Block Marker (MANDATORY, PRs only)
-
-When a Blocked-ing failure is diagnosed as an environment/infrastructure problem — a bug in the container image, a missing tool, a transient infra issue — rather than a bug in the PR's own code, add a machine-readable marker alongside the diagnosis so `oneshot` can auto-clear `Blocked` once the fix has actually shipped, instead of the PR sitting blocked until a human happens to notice (credfeto/credfeto-orchestrator#1118):
-
-1. Post the full human-readable diagnosis as normal — root cause, evidence, and (if known) the fix needed.
-2. Append a single trailer line to that same comment:
-
-   ```text
-   <!-- orchestrator:env-block image-sha=${IMAGE_SHA_DEVELOPMENT_AGENT} -->
-   ```
-
-   Read `IMAGE_SHA_DEVELOPMENT_AGENT` from your own container environment (the same value printed at session start as part of "Image layer provenance") — this records which image build was current when you made the diagnosis.
-3. Apply `Blocked` exactly as in the section above.
-4. Use this marker **only** for a genuine environment/infrastructure diagnosis. `oneshot` auto-clears `Blocked` the moment it observes a differently-built agent image, with no further human involvement — marking a real code question or design decision this way would resume work before a human actually answered it.
-
-This convention only applies to PRs (there is no container session, and therefore no image to diagnose against, before a PR/branch exists). Everything else about the Blocked-label convention above is unchanged.
-
 ### Comment Replies (MANDATORY)
 
 Reply to every PR or issue comment that prompted an action:

--- a/ai/global/agent-roles.instructions.md
+++ b/ai/global/agent-roles.instructions.md
@@ -166,7 +166,7 @@ When a Blocked-ing failure is diagnosed as an environment/infrastructure problem
 
 This convention only applies to PRs (there is no container session, and therefore no image to diagnose against, before a PR/branch exists). Everything else about the Blocked-label convention above is unchanged.
 
-### Human Comment Requests (MANDATORY)
+### Human Comment Requests — Run First (MANDATORY)
 
 Before processing CI checks or continuing the review loop, scan **all** comments on the current PR and its linked issue(s) from trusted commenters for ad-hoc requests to create a new GitHub issue.
 
@@ -181,21 +181,32 @@ For each such request that has not already been actioned (i.e. no reply from you
    gh issue create --repo <owner/repo> \
      --title "<concise title from the request>" \
      --body "<description from the request>" \
-     --label "<priority label from the request, or the commenter's usual priority if unspecified>"
+     --label "<priority label from the request, or 'Medium' if unspecified>"
    ```
 
-3. Reply to the original comment with the new issue number:
+3. Reply to the original comment with the new issue number. Use the correct command depending on where the request appeared:
 
-   ```bash
-   gh pr comment <number> --repo <owner/repo> --body "$(cat <<'COMMENT'
-   Raised as #<new-issue-number>.
-   COMMENT
-   )"
-   ```
+   - If the request was on a **PR**:
+
+     ```bash
+     gh pr comment <pr-number> --repo <owner/repo> --body "$(cat <<'COMMENT'
+     Raised as #<new-issue-number>.
+     COMMENT
+     )"
+     ```
+
+   - If the request was on an **issue** (including a linked issue):
+
+     ```bash
+     gh issue comment <issue-number> --repo <owner/repo> --body "$(cat <<'COMMENT'
+     Raised as #<new-issue-number>.
+     COMMENT
+     )"
+     ```
 
 4. Only after all such requests are actioned, continue with the normal CI/review workflow.
 
-The same rule applies when picking up an **issue**: if any comment on that issue requests a sub-issue to be raised, create it and reply before proceeding with implementation work.
+The same rule applies when picking up an **issue**: if any comment on that issue requests a sub-issue to be raised, create it and reply (using `gh issue comment`) before proceeding with implementation work.
 
 ### Comment Replies (MANDATORY)
 

--- a/ai/global/agent-roles.instructions.md
+++ b/ai/global/agent-roles.instructions.md
@@ -166,6 +166,37 @@ When a Blocked-ing failure is diagnosed as an environment/infrastructure problem
 
 This convention only applies to PRs (there is no container session, and therefore no image to diagnose against, before a PR/branch exists). Everything else about the Blocked-label convention above is unchanged.
 
+### Human Comment Requests (MANDATORY)
+
+Before processing CI checks or continuing the review loop, scan **all** comments on the current PR and its linked issue(s) from trusted commenters for ad-hoc requests to create a new GitHub issue.
+
+A request is identified by any natural-language phrasing such as: "raise an issue", "create an issue", "add an issue", "open an issue", "file an issue", or similar variants (case-insensitive).
+
+For each such request that has not already been actioned (i.e. no reply from you linking to a newly created issue):
+
+1. Search for an existing open **or closed** issue covering the same topic — do not create duplicates.
+2. If no duplicate exists, create the issue immediately:
+
+   ```bash
+   gh issue create --repo <owner/repo> \
+     --title "<concise title from the request>" \
+     --body "<description from the request>" \
+     --label "<priority label from the request, or the commenter's usual priority if unspecified>"
+   ```
+
+3. Reply to the original comment with the new issue number:
+
+   ```bash
+   gh pr comment <number> --repo <owner/repo> --body "$(cat <<'COMMENT'
+   Raised as #<new-issue-number>.
+   COMMENT
+   )"
+   ```
+
+4. Only after all such requests are actioned, continue with the normal CI/review workflow.
+
+The same rule applies when picking up an **issue**: if any comment on that issue requests a sub-issue to be raised, create it and reply before proceeding with implementation work.
+
 ### Comment Replies (MANDATORY)
 
 Reply to every PR or issue comment that prompted an action:

--- a/ai/global/agent-roles.instructions.md
+++ b/ai/global/agent-roles.instructions.md
@@ -208,6 +208,23 @@ For each such request that has not already been actioned (i.e. no reply from you
 
 The same rule applies when picking up an **issue**: if any comment on that issue requests a sub-issue to be raised, create it and reply (using `gh issue comment`) before proceeding with implementation work.
 
+### Environment/Infrastructure Block Marker (MANDATORY, PRs only)
+
+When a Blocked-ing failure is diagnosed as an environment/infrastructure problem — a bug in the container image, a missing tool, a transient infra issue — rather than a bug in the PR's own code, add a machine-readable marker alongside the diagnosis so `oneshot` can auto-clear `Blocked` once the fix has actually shipped, instead of the PR sitting blocked until a human happens to notice (credfeto/credfeto-orchestrator#1118):
+
+1. Post the full human-readable diagnosis as normal — root cause, evidence, and (if known) the fix needed.
+2. Append a single trailer line to that same comment:
+
+   ```text
+   <!-- orchestrator:env-block image-sha=${IMAGE_SHA_DEVELOPMENT_AGENT} -->
+   ```
+
+   Read `IMAGE_SHA_DEVELOPMENT_AGENT` from your own container environment (the same value printed at session start as part of "Image layer provenance") — this records which image build was current when you made the diagnosis.
+3. Apply `Blocked` exactly as in the section above.
+4. Use this marker **only** for a genuine environment/infrastructure diagnosis. `oneshot` auto-clears `Blocked` the moment it observes a differently-built agent image, with no further human involvement — marking a real code question or design decision this way would resume work before a human actually answered it.
+
+This convention only applies to PRs (there is no container session, and therefore no image to diagnose against, before a PR/branch exists). Everything else about the Blocked-label convention above is unchanged.
+
 ### Comment Replies (MANDATORY)
 
 Reply to every PR or issue comment that prompted an action:


### PR DESCRIPTION
## Summary

- Adds a new **Human Comment Requests (MANDATORY)** section to the Orchestrator role in `ai/global/agent-roles.instructions.md`
- The section is positioned before CI Checks, requiring the Orchestrator to scan all PR/issue comments from trusted commenters for ad-hoc requests to create GitHub issues
- For each unactioned request, the Orchestrator must: search for duplicates, create the issue if none exists, and reply to the original comment with the issue number

## Background

Related to credfeto/credfeto-orchestrator#306 — the Orchestrator was ignoring comments asking it to raise a separate issue, instead continuing straight to CI check processing.

## Test strategy

Documentation/instructions-only change — verified by re-reading the modified section to confirm the rule is unambiguous, correctly positioned, and does not conflict with the existing Comment Replies or CI Checks sections.