### PR TITLE
feat(orchestrator): add ad-hoc prompt intake and traceability rules

### DIFF
--- a/ai/global/agent-roles.instructions.md
+++ b/ai/global/agent-roles.instructions.md
@@ -148,6 +148,7 @@ When asking a question in a PR or issue comment and waiting for an answer before
    - PR: `gh pr edit <number> --repo <owner/repo> --add-label "Blocked"`
 2. Do **not** continue working on the item until the label is removed.
 3. Use **only** the `Blocked` label for this purpose — do **not** use labels like `do not merge`, `needs review`, or any other substitute. The orchestrator only recognises `Blocked` when deciding whether to skip an item.
+4. **Live-chat approval is not sufficient on its own.** If a human answers or approves in a live chat session rather than posting a GitHub comment directly, post the comment yourself — quoting the live instruction — before removing `Blocked` or resuming work. The record must survive even if the chat session is lost.
 
 ### Environment/Infrastructure Block Marker (MANDATORY, PRs only)
 

--- a/ai/global/agent-roles.instructions.md
+++ b/ai/global/agent-roles.instructions.md
@@ -148,7 +148,7 @@ When asking a question in a PR or issue comment and waiting for an answer before
    - PR: `gh pr edit <number> --repo <owner/repo> --add-label "Blocked"`
 2. Do **not** continue working on the item until the label is removed.
 3. Use **only** the `Blocked` label for this purpose — do **not** use labels like `do not merge`, `needs review`, or any other substitute. The orchestrator only recognises `Blocked` when deciding whether to skip an item.
-4. **Live-chat approval is not sufficient on its own.** If a human answers or approves in a live chat session rather than posting a GitHub comment directly, post the comment yourself — quoting the live instruction — before removing `Blocked` or resuming work. The record must survive even if the chat session is lost.
+4. **Live-chat approval is not sufficient on its own.** If a human answers or approves in a live chat session rather than posting a GitHub comment directly, post the comment yourself — quoting the live instruction — before resuming work (and before asking for `Blocked` to be removed). The record must survive even if the chat session is lost.
 
 ### Environment/Infrastructure Block Marker (MANDATORY, PRs only)
 

--- a/ai/global/index.md
+++ b/ai/global/index.md
@@ -15,7 +15,7 @@ Read all of these before starting any task, regardless of language or context.
 | File | Covers |
 | --- | --- |
 | [git.instructions.md](git.instructions.md) | Prerequisites, build/test verification, git identity/GPG, branching, version-conflict merge resolution, commits, GitHub issues |
-| [task-workflow.instructions.md](task-workflow.instructions.md) | Agent routing table, model selection, failure handling, issue/PR assignment, commit cadence, resuming work, command timeouts |
+| [task-workflow.instructions.md](task-workflow.instructions.md) | Agent routing table, model selection, failure handling, issue/PR assignment, commit cadence, resuming work, command timeouts, ad-hoc prompt intake, prompt traceability |
 | [code-quality.instructions.md](code-quality.instructions.md) | Code coverage, tests, async, immutability, parameterised tests, refactoring |
 | [documentation.instructions.md](documentation.instructions.md) | README, CHANGELOG conventions |
 | [security.instructions.md](security.instructions.md) | No secrets in code, input validation, output sanitisation |

--- a/ai/global/task-workflow.instructions.md
+++ b/ai/global/task-workflow.instructions.md
@@ -53,7 +53,7 @@ Applies whenever a human asks you to _do_ something in the context of a repo (a 
    - Labels: `AI-Work` and `Blocked` (minimum) — always, regardless of who initiated the underlying task; add other relevant labels (e.g. priority) as appropriate.
 2. Use Plan Mode to work out scope, affected files, and approach, and post it as an `## Implementation Plan` issue comment per the format in [agent-roles.instructions.md](agent-roles.instructions.md#issue-workflow--plan-first-new-issues-only).
 3. As open questions are identified, add each as an issue comment as soon as it's identified — do not batch them all until the end.
-4. Do not remove `Blocked` until an explicit human approval comment exists (`approved` / `go ahead` / `looks good` / `lgtm`) — if approval came via live chat, mirror it as a GitHub comment first (see [Blocked Label](agent-roles.instructions.md#blocked-label)) — then wait for the human to remove `Blocked`.
+4. Do not proceed until an explicit human approval comment exists (`approved` / `go ahead` / `looks good` / `lgtm`) and `Blocked` is removed — if approval came via live chat, mirror it as a GitHub comment first (see [Blocked Label](agent-roles.instructions.md#blocked-label)).
 5. Once approved and `Blocked` is removed:
    - If the request needs a code change, proceed via the routing table below and open a PR referencing the issue when ready.
    - If the request is read-only/informational (no code change), post the answer as an issue comment and close the issue.

--- a/ai/global/task-workflow.instructions.md
+++ b/ai/global/task-workflow.instructions.md
@@ -34,7 +34,7 @@ When selecting the next issue to work on, prefer issues with higher-priority lab
 
 ## GitHub Issue Creation (MANDATORY)
 
-When asked to create or add a GitHub issue (i.e. the issue itself is the requested deliverable):
+When asked to create or update a GitHub issue (i.e. the issue itself is the requested deliverable):
 
 1. Enter Plan Mode.
 2. Work out at a high level what code change the issue would represent — scope, affected files, approach.

--- a/ai/global/task-workflow.instructions.md
+++ b/ai/global/task-workflow.instructions.md
@@ -50,7 +50,7 @@ Applies whenever a human asks you to _do_ something in the context of a repo (a 
 1. Before taking any other action (including answering a read-only question), create a GitHub issue in the current repo:
    - Title: a concise summary of the prompt.
    - Body: the prompt, verbatim, as the starting point.
-   - Labels: `AI-Work` and `Blocked` — always, regardless of who initiated the underlying task.
+   - Labels: `AI-Work` and `Blocked` (minimum) — always, regardless of who initiated the underlying task; add other relevant labels (e.g. priority) as appropriate.
 2. Use Plan Mode to work out scope, affected files, and approach, and post it as an `## Implementation Plan` issue comment per the format in [agent-roles.instructions.md](agent-roles.instructions.md#issue-workflow--plan-first-new-issues-only).
 3. As open questions are identified, add each as an issue comment as soon as it's identified — do not batch them all until the end.
 4. Do not remove `Blocked` until an explicit human approval comment exists (`approved` / `go ahead` / `looks good` / `lgtm`) — if approval came via live chat, mirror it as a GitHub comment first (see [Blocked Label](agent-roles.instructions.md#blocked-label)) — then wait for the human to remove `Blocked`.

--- a/ai/global/task-workflow.instructions.md
+++ b/ai/global/task-workflow.instructions.md
@@ -53,7 +53,7 @@ Applies whenever a human asks you to _do_ something in the context of a repo (a 
    - Labels: `AI-Work` and `Blocked` — always, regardless of who initiated the underlying task.
 2. Use Plan Mode to work out scope, affected files, and approach, and post it as an `## Implementation Plan` issue comment per the format in [agent-roles.instructions.md](agent-roles.instructions.md#issue-workflow--plan-first-new-issues-only).
 3. As open questions are identified, add each as an issue comment as soon as it's identified — do not batch them all until the end.
-4. Do not remove `Blocked` yourself. Wait for an explicit human approval comment (`approved` / `go ahead` / `looks good` / `lgtm`) on the issue — see the live-chat-approval rule under [Blocked Label](agent-roles.instructions.md#blocked-label).
+4. Do not remove `Blocked` until an explicit human approval comment exists (`approved` / `go ahead` / `looks good` / `lgtm`) — if approval came via live chat, mirror it as a GitHub comment first (see [Blocked Label](agent-roles.instructions.md#blocked-label)) — then wait for the human to remove `Blocked`.
 5. Once approved and `Blocked` is removed:
    - If the request needs a code change, proceed via the routing table below and open a PR referencing the issue when ready.
    - If the request is read-only/informational (no code change), post the answer as an issue comment and close the issue.

--- a/ai/global/task-workflow.instructions.md
+++ b/ai/global/task-workflow.instructions.md
@@ -34,12 +34,38 @@ When selecting the next issue to work on, prefer issues with higher-priority lab
 
 ## GitHub Issue Creation (MANDATORY)
 
-When asked to create or add a GitHub issue:
+When asked to create or add a GitHub issue (i.e. the issue itself is the requested deliverable):
 
 1. Enter Plan Mode.
 2. Work out at a high level what code change the issue would represent — scope, affected files, approach.
 3. Exit Plan Mode and return to auto.
 4. Create the issue, using the plan output to write a meaningful description.
+
+This is distinct from [Ad-Hoc Prompt Intake](#ad-hoc-prompt-intake-mandatory) below — that section covers being asked to _do_ something, where the issue is a tracking side-effect rather than the deliverable itself.
+
+## Ad-Hoc Prompt Intake (MANDATORY)
+
+Applies whenever a human asks you to _do_ something in the context of a repo (a task — not a request to raise an issue, which is covered above), and no existing issue or PR has already been specified as the thing to work on. No exception for triviality of the request, and no exception for the `credfeto/cs-template` repo itself.
+
+1. Before taking any other action (including answering a read-only question), create a GitHub issue in the current repo:
+   - Title: a concise summary of the prompt.
+   - Body: the prompt, verbatim, as the starting point.
+   - Labels: `AI-Work` and `Blocked` — always, regardless of who initiated the underlying task.
+2. Use Plan Mode to work out scope, affected files, and approach, and post it as an `## Implementation Plan` issue comment per the format in [agent-roles.instructions.md](agent-roles.instructions.md#issue-workflow--plan-first-new-issues-only).
+3. As open questions are identified, add each as an issue comment as soon as it's identified — do not batch them all until the end.
+4. Do not remove `Blocked` yourself. Wait for an explicit human approval comment (`approved` / `go ahead` / `looks good` / `lgtm`) on the issue — see the live-chat-approval rule under [Blocked Label](agent-roles.instructions.md#blocked-label).
+5. Once approved and `Blocked` is removed:
+   - If the request needs a code change, proceed via the routing table below and open a PR referencing the issue when ready.
+   - If the request is read-only/informational (no code change), post the answer as an issue comment and close the issue.
+6. See [Prompt Traceability](#prompt-traceability-mandatory) below for further prompts once an issue or PR already exists for the work.
+
+## Prompt Traceability (MANDATORY)
+
+Once a request is already tracked by an issue or PR (including one just created under [Ad-Hoc Prompt Intake](#ad-hoc-prompt-intake-mandatory) above), every subsequent prompt from the human that changes, redirects, or adds detail to that work must be recorded on that issue/PR:
+
+- Comment with the prompt (verbatim, or a faithful summary for long prompts) and how it was resolved — a code change, an answered question, a scope adjustment, etc.
+- Post this before or immediately after acting on the prompt — do not let several prompts accumulate unrecorded.
+- This applies whether the prompt arrived as a live chat message or as a GitHub comment (GitHub comments are already covered by [Comment Replies](agent-roles.instructions.md#comment-replies-mandatory)).
 
 ## PR Lifecycle
 

--- a/ai/global/task-workflow.instructions.md
+++ b/ai/global/task-workflow.instructions.md
@@ -39,7 +39,7 @@ When asked to create or update a GitHub issue (i.e. the issue itself is the requ
 1. Enter Plan Mode.
 2. Work out at a high level what code change the issue would represent — scope, affected files, approach.
 3. Exit Plan Mode and return to auto.
-4. Create the issue, using the plan output to write a meaningful description.
+4. Create the issue, or update the existing issue, using the plan output to write a meaningful description.
 
 This is distinct from [Ad-Hoc Prompt Intake](#ad-hoc-prompt-intake-mandatory) below — that section covers being asked to _do_ something, where the issue is a tracking side-effect rather than the deliverable itself.
 


### PR DESCRIPTION
## Summary
- New **Ad-Hoc Prompt Intake (MANDATORY)** section in `task-workflow.instructions.md`: any ad-hoc "do X" prompt with no existing issue/PR gets a tracking issue first (`AI-Work` + `Blocked`, prompt verbatim), before any other action — no exceptions for triviality or for `cs-template` itself. This is explicitly distinguished from the existing "asked to raise an issue" flow, which is unchanged.
- New **Prompt Traceability (MANDATORY)** section: once work is tracked, every further prompt that changes/adds detail gets logged as an issue/PR comment with the prompt and resolution.
- `agent-roles.instructions.md`: **Blocked Label** section now requires live-chat approvals to be mirrored as a posted GitHub comment before `Blocked` is removed — so the record survives a lost chat session.
- `index.md`: updated the `task-workflow.instructions.md` "Covers" summary.

Motivation: crash resilience — after repeated local session/PC crashes, state about what was asked and decided should live durably in GitHub, not only in an ephemeral chat session.

Closes #949

## Test plan
- [x] `pre-commit run --all-files` (markdownlint, etc.) passes
- [x] Documentation-only change; verified cross-references (`#anchor` links) resolve to real headings
- [x] Verified no conflicting/duplicate rules introduced in `git.instructions.md` (left unchanged per correction from human review — "raise an issue" requests keep existing behaviour, separate from ad-hoc task tracking)