### PR TITLE
docs(ai): document MockBase<T> move to FunFair.Test.Infrastructure.Mocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ## [Unreleased]
 ### Security
 ### Added
+- dotnet.instructions: document MockBase<T> move to FunFair.Test.Infrastructure.Mocks namespace (from FunFair.Test.Common.Mocks) as of FunFair.Test.Common 6.3.1.2342
 - git.instructions: mandatory rule requiring verbatim command output in PR/issue comments before any diagnosis when a git command fails
 ### Fixed
 - on_new_pr.yml: inline composite action logic to fix local action path resolution failure under pull_request_target

--- a/ai/global/dotnet.instructions.md
+++ b/ai/global/dotnet.instructions.md
@@ -258,7 +258,21 @@ The `FunFair.Test.*` packages in this section are org-owned — see [dotnet-owne
 
 ### FunFair.Test.Infrastructure
 
-Add `FunFair.Test.Infrastructure` as a package reference when your tests need HTTP mocking beyond what `FunFair.Test.Common` provides. It supplies:
+`FunFair.Test.Infrastructure` is already a transitive dependency of `FunFair.Test.Common` — no explicit `<PackageReference>` is needed. It supplies:
+
+**`MockBase<T>`** (`FunFair.Test.Infrastructure.Mocks`):
+
+As of `FunFair.Test.Common` 6.3.1.2342, `MockBase<T>` was moved from `FunFair.Test.Common.Mocks` to `FunFair.Test.Infrastructure.Mocks`. When upgrading to 6.3.1.2342 or later, update the `using` directive in any file that references `MockBase<T>`:
+
+```csharp
+// BEFORE (FunFair.Test.Common < 6.3.1.2342)
+using FunFair.Test.Common.Mocks;
+
+// AFTER (FunFair.Test.Common >= 6.3.1.2342)
+using FunFair.Test.Infrastructure.Mocks;
+```
+
+No new `<PackageReference>` is required — `FunFair.Test.Infrastructure` is already a transitive dependency.
 
 **`HttpClientFactoryExtensions`** (`FunFair.Test.Infrastructure.Extensions`):
 


### PR DESCRIPTION
## Summary

- Updates `ai/global/dotnet.instructions.md` to document that `MockBase<T>` moved from `FunFair.Test.Common.Mocks` to `FunFair.Test.Infrastructure.Mocks` as of `FunFair.Test.Common` 6.3.1.2342
- Clarifies that `FunFair.Test.Infrastructure` is already a transitive dependency of `FunFair.Test.Common` — no explicit `<PackageReference>` is needed
- Updates the section introduction to reflect that no explicit package reference is needed (previously said "Add `FunFair.Test.Infrastructure` as a package reference")

## Test plan

- [ ] Verify the diff accurately documents the namespace change (`FunFair.Test.Common.Mocks` → `FunFair.Test.Infrastructure.Mocks`)
- [ ] Verify the version number (6.3.1.2342) matches the issue description
- [ ] Verify no other instruction files conflict with this change

Closes #925