### PR TITLE
docs(ai): identity check is now enforced by the global pre-commit hook

### DIFF
--- a/ai/global/git.examples.md
+++ b/ai/global/git.examples.md
@@ -4,7 +4,7 @@
 
 ## Git Identity Check Script
 
-Run before any commit to verify identity and GPG signing:
+This check is enforced automatically on every commit by the global pre-commit hook (`credfeto-global-pre-commit`'s `src/scripts/check-identity`) — see [Git Identity Check](git.instructions.md#git-identity-check-mandatory-before-any-commit). Use the script below only as a manual fallback when [Pre-Commit Hook Verification](git.instructions.md#pre-commit-hook-verification-mandatory-before-blocking) finds the hook is not installed in any git config scope:
 
 ```bash
 #!/bin/sh

--- a/ai/global/git.instructions.md
+++ b/ai/global/git.instructions.md
@@ -30,9 +30,14 @@ This ensures CI results are unambiguous — pre-existing failures are resolved b
 
 Never block work based on inspecting config files and deducing that a tool might be missing. Always verify by actually running the hook:
 
-1. Stage your changes.
-2. Run the pre-commit hook directly: `<hooks-path>/pre-commit` (find the path with `git config --global core.hooksPath`).
-3. Only block if the hook **actually fails** with a real error.
+1. Find the installed hooks path by checking `core.hooksPath` at each git config scope in order — the **first** scope where it is set is treated as sufficient; do not check the remaining scopes:
+   1. `git config --system --get core.hooksPath`
+   2. `git config --global --get core.hooksPath`
+   3. `git config --local --get core.hooksPath` (run inside the repo)
+   If none of the three scopes returns a value, the hook is **not installed** — see [Git Identity Check](#git-identity-check-mandatory-before-any-commit) for what that means for identity verification.
+2. Stage your changes.
+3. Run the pre-commit hook directly: `<hooks-path>/pre-commit`, using the path found in step 1.
+4. Only block if the hook **actually fails** with a real error.
 
 Inspecting `.pre-commit-config.yaml` and concluding a `language: system` tool is absent is not sufficient — the tool may be installed in a location not visible to `command -v` in the current shell context.
 
@@ -42,9 +47,11 @@ Build must pass and all tests must pass before committing or pushing. If they fa
 
 ## Git Identity Check (MANDATORY before any commit)
 
-Before any commit, verify identity and GPG signing are correct — see [git.examples.md](git.examples.md) for the check script.
+Identity and GPG signing (`user.email`, `commit.gpgsign`, `user.signingkey`) are verified automatically on every commit by the global pre-commit hook (`credfeto-global-pre-commit`'s `src/scripts/check-identity`) — see [git.examples.md](git.examples.md) for the check it runs.
 
-**If either check fails: stop all work, do not commit, and report the misconfiguration.**
+**If the hook fails with an identity or signing error: stop all work, do not commit, and report the misconfiguration.**
+
+If [Pre-Commit Hook Verification](#pre-commit-hook-verification-mandatory-before-blocking) finds the hook is **not installed** in any git config scope, automatic enforcement does not apply — run the identity check manually using the script in [git.examples.md](git.examples.md) before committing.
 
 ## Pre-Commit Branch Check
 


### PR DESCRIPTION
# Description

Previously `git.instructions.md` told the AI to run the git identity/GPG check manually before every commit — a fresh ad-hoc script pasted into Bash each time, requiring a permission prompt every commit since the harness can't verify an inline script it hasn't seen before.

`credfeto-global-pre-commit` now enforces this automatically via `src/scripts/check-identity`, wired into the pre-commit hook itself (credfeto/credfeto-global-pre-commit#171), so it runs as a trusted side effect of `git commit` instead. This documents that as the primary mechanism:

- `git.instructions.md`: Git Identity Check now describes automatic enforcement by the hook, with the manual script retained only as a fallback for repos where the hook isn't installed.
- `git.instructions.md`: Pre-Commit Hook Verification previously only checked `core.hooksPath` at `--global` scope via `git config --global core.hooksPath`, which silently returns nothing on a machine where the hook was installed with `--system` instead. Now checks `--system`, then `--global`, then `--local`, treating the first scope found as sufficient.
- `git.examples.md`: reframes the identity check script as the documented fallback/reference rather than something run on every commit.

## Test plan
- [x] `pre-commit` hooks passed on commit (including the new automatic identity check itself, dogfooded).
- N/A — documentation-only change to AI instruction files (no changelog entry required per `ai/global/changelog.instructions.md`).

## Related
- credfeto/credfeto-global-pre-commit#171