### PR TITLE
docs(ai): guard against agent-sandbox-caused false timeouts in benchmark/perf tests

### DIFF
--- a/ai/global/task-workflow.instructions.md
+++ b/ai/global/task-workflow.instructions.md
@@ -235,6 +235,15 @@ Never pass a tool-level timeout that could truncate `pre-commit`, a `git commit`
 - If even the maximum available timeout is not enough, use `run_in_background` and the Monitor tool instead of accepting a truncated run.
 - A killed run does not just fail — it skips the target process's own cleanup (a bash `EXIT` trap, .NET's `IDisposable` teardown, etc.), leaving orphaned temp directories, lock files, or half-applied state behind. Confirmed in practice: a killed `bats` run left thousands of orphaned fixture directories under a shared runtime directory, which went on to break an unrelated tool (`firejail`) that walked the same path.
 
+### Sandbox-Caused False Timeouts in Benchmark/Perf Tests (MANDATORY)
+
+If a `dotnet test`/`dotnet build` run that includes a benchmark or performance-test project fails with a timeout-shaped error (e.g. "configured timeout ... reached", "command took longer than the timeout", "Failed to set up high priority (Permission denied)"), do not conclude this is a genuine pre-existing/environmental limitation in the codebase before ruling out your own execution sandbox as the cause:
+
+1. Re-run the identical command with sandboxing disabled if your tool supports it (e.g. a `dangerouslyDisableSandbox`-style flag).
+2. Reproducing the same failure on a clean `main`/base branch does **not** rule out the sandbox — if you're still running inside the same sandboxed shell, that reproduction is confounded and proves nothing about the codebase itself.
+3. If the failure disappears or measurably improves with sandboxing disabled, the sandbox was throttling CPU/resources — report this plainly; do not describe the benchmark suite as broken or flaky.
+4. If still uncertain after disabling sandboxing, say so explicitly and ask the user to run the identical command in their own terminal before asserting any diagnosis — never present a sandbox artifact as a confirmed pre-existing bug.
+
 ## Multi-Agent Implementation and Review Pattern
 
 ### Model Selection


### PR DESCRIPTION
## Summary

Adds a mandatory "Sandbox-Caused False Timeouts in Benchmark/Perf Tests" subsection to `ai/global/task-workflow.instructions.md`, immediately after the existing "Never Truncate Test/Commit Commands (MANDATORY)" section.

When a `dotnet test`/`dotnet build` run that includes a benchmark or performance-test project fails with a timeout-shaped error, agents must rule out their own execution sandbox throttling CPU/resources before concluding the failure is a genuine pre-existing/environmental limitation in the codebase — including not treating a reproduction on `main` as proof, since that reproduction runs in the same sandbox.

This was reported from a live incident in `funfair-tech/funfair-server-code-analysis` where an agent misdiagnosed sandbox throttling as a pre-existing environmental issue.

No CHANGELOG entry: per `ai/global/changelog.instructions.md`, entries are skipped both because this repo is `-template` and because the change is to AI instruction files.

Closes #946

## Test plan

- [ ] No automated tests apply to Markdown instruction files.
- [x] Verified the new subsection is inserted between "Never Truncate Test/Commit Commands (MANDATORY)" and "## Multi-Agent Implementation and Review Pattern", matching the approved implementation plan.
- [x] Commit-time pre-commit hook passed on the changed file (markdownlint included).
- [x] Ran the full `pre-commit run --all-files` baseline separately — it surfaces pre-existing, unrelated failures on `main` (yamllint on `.github/dependabot.yml`/`.github/FUNDING.yml`, markdownlint on `CONTRIBUTING.md`/`CLAUDE.md`) not touched by this PR; tracked in #958, not fixed here to avoid scope creep.