### PR TITLE
docs(ai): add global Docker/Podman instructions

### DIFF
--- a/ai/global/docker.instructions.md
+++ b/ai/global/docker.instructions.md
@@ -1,0 +1,35 @@
+# Docker Instructions
+
+> Load when: any `Dockerfile`, `Containerfile`, `docker-compose*.yml`, `compose.yml`, or `.dockerignore` is present, or container work is needed.
+
+[Back to Global Instructions Index](index.md)
+
+## Container Runner Detection
+
+- The container runner on a given machine may be **Docker or Podman** — never assume one is installed.
+- Detect which is available and use that: prefer `docker` if present, otherwise fall back to `podman`. Check with `command -v docker` / `command -v podman` before running any container command.
+- Do the same for the compose tool: `docker compose` (or legacy `docker-compose`) vs `podman-compose`.
+- Do not hardcode `docker` in scripts that need to run on either — resolve the runner once at the top of the script and use a variable.
+
+## Dockerfile Authoring
+
+- Use multi-stage builds: a `build`/`sdk` stage for compiling/installing, and a minimal runtime stage that copies only the built artefacts across.
+- Pin base image versions explicitly (e.g. `mcr.microsoft.com/dotnet/sdk:9.0` or a digest) — never `latest`.
+- Order layers from least to most frequently changing so the build cache is preserved (dependency manifests and restore steps before source copy).
+- Run the container process as a non-root user; create a dedicated user in the image rather than running as `root`.
+- Add a `.dockerignore` covering build output, `.git`, local secrets/env files, and IDE directories — never rely on the daemon to filter these out of the build context.
+- Never `COPY`/`ADD` secrets, credentials, or `.env` files into an image layer — even if removed in a later layer, they remain in the image history. Pass secrets at build time via BuildKit `--secret` (or the Podman equivalent) or inject them at runtime.
+
+## Compose Conventions
+
+- Pin image tags/digests in `docker-compose.yml` / `compose.yml` the same way as Dockerfiles — no `latest`.
+- Define explicit named networks rather than relying on the default network when more than one service needs to communicate.
+- Use named volumes for persistent state; bind-mount only for local development conveniences (source code, config overrides).
+- Keep environment-specific overrides in a separate override file (e.g. `compose.override.yml`) rather than branching logic inside the base file.
+
+## Security Basics
+
+- Prefer minimal base images (`-alpine`, `-slim`, or distroless) for runtime stages to reduce attack surface.
+- Scan images for known vulnerabilities before publishing (e.g. `docker scout`, `trivy`, or the CI-configured scanner) — see [security.instructions.md](security.instructions.md#dependency-vulnerability-scanning) for the general dependency-scanning policy.
+- Never bake secrets, credentials, or tokens into an image layer — see the Dockerfile Authoring section above.
+- Set explicit resource limits (memory/CPU) in compose/runtime configuration for anything other than local development.

--- a/ai/global/docker.instructions.md
+++ b/ai/global/docker.instructions.md
@@ -6,7 +6,7 @@
 
 ## Container Runner Detection
 
-- The container runner on a given machine may be **Docker or Podman** — never assume one is installed.
+- The container runner on a given machine may be **Docker or Podman** — never assume one is installed.  If neither is installed, the STOP with an error message.
 - Detect which is available and use that: prefer `docker` if present, otherwise fall back to `podman`. Check with `command -v docker` / `command -v podman` before running any container command.
 - Do the same for the compose tool: `docker compose` (or legacy `docker-compose`) vs `podman-compose`.
 - Do not hardcode `docker` in scripts that need to run on either — resolve the runner once at the top of the script and use a variable.
@@ -14,18 +14,20 @@
 ## Dockerfile Authoring
 
 - Use multi-stage builds: a `build`/`sdk` stage for compiling/installing, and a minimal runtime stage that copies only the built artefacts across.
-- Pin base image versions explicitly (e.g. `mcr.microsoft.com/dotnet/sdk:9.0` or a digest) — never `latest`.
+- Pin base image versions explicitly (e.g. `mcr.microsoft.com/dotnet/sdk:9.0` or a digest) — never `latest`, unless explictly required to by local instructions.
 - Order layers from least to most frequently changing so the build cache is preserved (dependency manifests and restore steps before source copy).
 - Run the container process as a non-root user; create a dedicated user in the image rather than running as `root`.
-- Add a `.dockerignore` covering build output, `.git`, local secrets/env files, and IDE directories — never rely on the daemon to filter these out of the build context.
+- Prefer building an app outside the container and then copying in built files into the container image rather than building inside the container.
 - Never `COPY`/`ADD` secrets, credentials, or `.env` files into an image layer — even if removed in a later layer, they remain in the image history. Pass secrets at build time via BuildKit `--secret` (or the Podman equivalent) or inject them at runtime.
 
 ## Compose Conventions
 
 - Pin image tags/digests in `docker-compose.yml` / `compose.yml` the same way as Dockerfiles — no `latest`.
 - Define explicit named networks rather than relying on the default network when more than one service needs to communicate.
-- Use named volumes for persistent state; bind-mount only for local development conveniences (source code, config overrides).
+- Use external named volumes for persistent state; bind-mount only for local development conveniences (source code, config overrides).
 - Keep environment-specific overrides in a separate override file (e.g. `compose.override.yml`) rather than branching logic inside the base file.
+- Add `install` and `update` scripts to the repo that configures the environment and starts the container.
+- A `reset` script should also be provided that tears down an existing container and then calls `install`.
 
 ## Security Basics
 
@@ -33,3 +35,7 @@
 - Scan images for known vulnerabilities before publishing (e.g. `docker scout`, `trivy`, or the CI-configured scanner) — see [security.instructions.md](security.instructions.md#dependency-vulnerability-scanning) for the general dependency-scanning policy.
 - Never bake secrets, credentials, or tokens into an image layer — see the Dockerfile Authoring section above.
 - Set explicit resource limits (memory/CPU) in compose/runtime configuration for anything other than local development.
+- If there's a sudo or doas in the base image, ensure that it's not available in the container and that the container runs as a non-root user.
+- Ensure that the container doesn't have any unnecessary capabilities (e.g. `CAP_NET_ADMIN`) and that the container's user has the minimum required permissions.
+- Ensure that containers are defined with read-only filesystems (`read-only: true`) to prevent accidental or malicious modifications.
+- Ensure that containers have no way of getting additional capabilities or permissions.

--- a/ai/global/docker.instructions.md
+++ b/ai/global/docker.instructions.md
@@ -6,27 +6,27 @@
 
 ## Container Runner Detection
 
-- The container runner on a given machine may be **Docker or Podman** — never assume one is installed.  If neither is installed, the STOP with an error message.
+- The container runner on a given machine may be **Docker or Podman** — never assume one is installed. If neither is installed, stop immediately — do not attempt to install one yourself — and ask the user to install Docker or Podman before continuing.
 - Detect which is available and use that: prefer `docker` if present, otherwise fall back to `podman`. Check with `command -v docker` / `command -v podman` before running any container command.
 - Do the same for the compose tool: `docker compose` (or legacy `docker-compose`) vs `podman-compose`.
 - Do not hardcode `docker` in scripts that need to run on either — resolve the runner once at the top of the script and use a variable.
 
 ## Dockerfile Authoring
 
-- Use multi-stage builds: a `build`/`sdk` stage for compiling/installing, and a minimal runtime stage that copies only the built artefacts across.
-- Pin base image versions explicitly (e.g. `mcr.microsoft.com/dotnet/sdk:9.0` or a digest) — never `latest`, unless explictly required to by local instructions.
+- Prefer building the app outside the container (locally or in CI) and copying the pre-built artefacts into a minimal runtime image, rather than compiling inside the container. When the build must run inside the container, use multi-stage builds: a `build`/`sdk` stage for compiling/installing, and a minimal runtime stage that copies only the built artefacts across.
+- Pin base image versions explicitly (e.g. `alpine:3.20` or a digest) — never `latest`, unless explicitly required to by local instructions. The version shown is an example only and may be stale by the time you read this — check the image registry for the current stable release before pinning.
 - Order layers from least to most frequently changing so the build cache is preserved (dependency manifests and restore steps before source copy).
 - Run the container process as a non-root user; create a dedicated user in the image rather than running as `root`.
-- Prefer building an app outside the container and then copying in built files into the container image rather than building inside the container.
+- Add a `.dockerignore` covering build output, `.git`, local secrets/env files, and IDE directories — never rely on the daemon to filter these out of the build context. This applies even when copying in pre-built artefacts rather than building inside the container: the whole build context is still sent to the daemon, not just the files referenced by `COPY`.
 - Never `COPY`/`ADD` secrets, credentials, or `.env` files into an image layer — even if removed in a later layer, they remain in the image history. Pass secrets at build time via BuildKit `--secret` (or the Podman equivalent) or inject them at runtime.
 
 ## Compose Conventions
 
-- Pin image tags/digests in `docker-compose.yml` / `compose.yml` the same way as Dockerfiles — no `latest`.
+- Pin image tags/digests in `docker-compose.yml` / `compose.yml` the same way as Dockerfiles — no `latest`, unless explicitly required to by local instructions.
 - Define explicit named networks rather than relying on the default network when more than one service needs to communicate.
 - Use external named volumes for persistent state; bind-mount only for local development conveniences (source code, config overrides).
 - Keep environment-specific overrides in a separate override file (e.g. `compose.override.yml`) rather than branching logic inside the base file.
-- Add `install` and `update` scripts to the repo that configures the environment and starts the container.
+- Add `install` and `update` scripts to the repo: `install` performs first-time setup — creating any external volumes/networks, pulling or building images, and starting the containers; `update` pulls or rebuilds the latest images and restarts the containers without touching persistent volumes.
 - A `reset` script should also be provided that tears down an existing container and then calls `install`.
 
 ## Security Basics
@@ -37,5 +37,5 @@
 - Set explicit resource limits (memory/CPU) in compose/runtime configuration for anything other than local development.
 - If there's a sudo or doas in the base image, ensure that it's not available in the container and that the container runs as a non-root user.
 - Ensure that the container doesn't have any unnecessary capabilities (e.g. `CAP_NET_ADMIN`) and that the container's user has the minimum required permissions.
-- Ensure that containers are defined with read-only filesystems (`read-only: true`) to prevent accidental or malicious modifications.
+- Ensure that containers are defined with read-only filesystems (`read_only: true`) to prevent accidental or malicious modifications.
 - Ensure that containers have no way of getting additional capabilities or permissions.

--- a/ai/global/docker.instructions.md
+++ b/ai/global/docker.instructions.md
@@ -27,7 +27,7 @@
 - Use external named volumes for persistent state; bind-mount only for local development conveniences (source code, config overrides).
 - Keep environment-specific overrides in a separate override file (e.g. `compose.override.yml`) rather than branching logic inside the base file.
 - Add `install` and `update` scripts to the repo: `install` performs first-time setup — creating any external volumes/networks, pulling or building images, and starting the containers; `update` pulls or rebuilds the latest images and restarts the containers without touching persistent volumes.
-- A `reset` script should also be provided that tears down an existing container and then calls `install`.
+- A `reset` script should also be provided that tears down the existing containers and then calls `install`.
 
 ## Security Basics
 
@@ -35,7 +35,5 @@
 - Scan images for known vulnerabilities before publishing (e.g. `docker scout`, `trivy`, or the CI-configured scanner) — see [security.instructions.md](security.instructions.md#dependency-vulnerability-scanning) for the general dependency-scanning policy.
 - Never bake secrets, credentials, or tokens into an image layer — see the Dockerfile Authoring section above.
 - Set explicit resource limits (memory/CPU) in compose/runtime configuration for anything other than local development — confirm the runner actually enforces them (e.g. `deploy.resources.limits` is a Swarm construct that some Compose V2 versions ignore outside Swarm mode) rather than assuming the field alone provides protection.
-- If there's a sudo or doas in the base image, ensure that it's not available in the container and that the container runs as a non-root user.
-- Ensure that the container doesn't have any unnecessary capabilities (e.g. `CAP_NET_ADMIN`) and that the container's user has the minimum required permissions.
+- Run containers under least privilege: remove `sudo`/`doas` and other setuid privilege-escalation binaries from the final image, run as a non-root user, drop all capabilities by default and add back only the specific ones a service genuinely needs (e.g. `cap_drop: [ALL]` plus an explicit `cap_add` allowlist), and set `security_opt: [no-new-privileges:true]` (or the Podman equivalent) so the container can never acquire additional privileges at runtime.
 - Ensure that containers are defined with read-only filesystems (`read_only: true`) to prevent accidental or malicious modifications.
-- Ensure that containers have no way of getting additional capabilities or permissions.

--- a/ai/global/docker.instructions.md
+++ b/ai/global/docker.instructions.md
@@ -1,6 +1,6 @@
 # Docker Instructions
 
-> Load when: any `Dockerfile`, `Containerfile`, `docker-compose*.yml`, `compose.yml`, or `.dockerignore` is present, or container work is needed.
+> Load when: any `Dockerfile`, `Containerfile`, `docker-compose*.yml`, `docker-compose*.yaml`, `compose.yml`, `compose.yaml`, or `.dockerignore` is present, or container work is needed.
 
 [Back to Global Instructions Index](index.md)
 
@@ -8,13 +8,13 @@
 
 - The container runner on a given machine may be **Docker or Podman** — never assume one is installed. If neither is installed, stop immediately — do not attempt to install one yourself — and ask the user to install Docker or Podman before continuing.
 - Detect which is available and use that: prefer `docker` if present, otherwise fall back to `podman`. Check with `command -v docker` / `command -v podman` before running any container command.
-- Do the same for the compose tool: `docker compose` (or legacy `docker-compose`) vs `podman-compose`.
+- Do the same for the compose tool: `docker compose` and `podman compose` are subcommands of their respective CLIs, not standalone binaries, so detect them by running e.g. `docker compose version` / `podman compose version` rather than `command -v`; fall back to the legacy standalone `docker-compose` / `podman-compose` binaries only if the subcommand isn't available.
 - Do not hardcode `docker` in scripts that need to run on either — resolve the runner once at the top of the script and use a variable.
 
 ## Dockerfile Authoring
 
 - Prefer building the app outside the container (locally or in CI) and copying the pre-built artefacts into a minimal runtime image, rather than compiling inside the container. When the build must run inside the container, use multi-stage builds: a `build`/`sdk` stage for compiling/installing, and a minimal runtime stage that copies only the built artefacts across.
-- Pin base image versions explicitly (e.g. `alpine:3.20` or a digest) — never `latest`, unless explicitly required to by local instructions. The version shown is an example only and may be stale by the time you read this — check the image registry for the current stable release before pinning.
+- Pin base image versions explicitly (e.g. `alpine:3.20` or a digest) — never `latest`, unless explicitly required by local instructions. The version shown is an example only and may be stale by the time you read this — check the image registry for the current stable release before pinning.
 - Order layers from least to most frequently changing so the build cache is preserved (dependency manifests and restore steps before source copy).
 - Run the container process as a non-root user; create a dedicated user in the image rather than running as `root`.
 - Add a `.dockerignore` covering build output, `.git`, local secrets/env files, and IDE directories — never rely on the daemon to filter these out of the build context. This applies even when copying in pre-built artefacts rather than building inside the container: the whole build context is still sent to the daemon, not just the files referenced by `COPY`.
@@ -22,7 +22,7 @@
 
 ## Compose Conventions
 
-- Pin image tags/digests in `docker-compose.yml` / `compose.yml` the same way as Dockerfiles — no `latest`, unless explicitly required to by local instructions.
+- Pin image tags/digests in `docker-compose.yml` / `compose.yml` the same way as Dockerfiles — no `latest`, unless explicitly required by local instructions.
 - Define explicit named networks rather than relying on the default network when more than one service needs to communicate.
 - Use external named volumes for persistent state; bind-mount only for local development conveniences (source code, config overrides).
 - Keep environment-specific overrides in a separate override file (e.g. `compose.override.yml`) rather than branching logic inside the base file.
@@ -34,7 +34,7 @@
 - Prefer minimal base images (`-alpine`, `-slim`, or distroless) for runtime stages to reduce attack surface.
 - Scan images for known vulnerabilities before publishing (e.g. `docker scout`, `trivy`, or the CI-configured scanner) — see [security.instructions.md](security.instructions.md#dependency-vulnerability-scanning) for the general dependency-scanning policy.
 - Never bake secrets, credentials, or tokens into an image layer — see the Dockerfile Authoring section above.
-- Set explicit resource limits (memory/CPU) in compose/runtime configuration for anything other than local development.
+- Set explicit resource limits (memory/CPU) in compose/runtime configuration for anything other than local development — confirm the runner actually enforces them (e.g. `deploy.resources.limits` is a Swarm construct that some Compose V2 versions ignore outside Swarm mode) rather than assuming the field alone provides protection.
 - If there's a sudo or doas in the base image, ensure that it's not available in the container and that the container runs as a non-root user.
 - Ensure that the container doesn't have any unnecessary capabilities (e.g. `CAP_NET_ADMIN`) and that the container's user has the minimum required permissions.
 - Ensure that containers are defined with read-only filesystems (`read_only: true`) to prevent accidental or malicious modifications.

--- a/ai/global/index.md
+++ b/ai/global/index.md
@@ -30,7 +30,7 @@ Load these only when the work involves the relevant technology or context.
 | File | Load When | Covers |
 | --- | --- | --- |
 | [dotnet.instructions.md](dotnet.instructions.md) | Any `.csproj`, `.sln`, or `.slnx` file is present | Build/test, solution structure, test patterns, ValueTask, CancellationToken, NuGet audit |
-| [docker.instructions.md](docker.instructions.md) | Any `Dockerfile`, `Containerfile`, `.dockerignore`, or compose file is present, or container work is needed | Docker/Podman runner detection, Dockerfile authoring, compose conventions, image security basics |
+| [docker.instructions.md](docker.instructions.md) | Any `Dockerfile`, `Containerfile`, `.dockerignore`, `docker-compose*.yml`, `docker-compose*.yaml`, `compose.yml`, or `compose.yaml` is present, or container work is needed | Docker/Podman runner detection, Dockerfile authoring, compose conventions, image security basics |
 | [dotnet-owned-packages.instructions.md](dotnet-owned-packages.instructions.md) | Any `.csproj`, `.sln`, or `.slnx` file is present, or a `Credfeto.*`/`FunFair.*` package is encountered | Registry of org-owned NuGet packages with source repos — never decompile these |
 | [sql.instructions.md](sql.instructions.md) | Any `.sql` file or SQL project is present | SQL linting, local DB connection, performance optimisation |
 | [shell-scripts.instructions.md](shell-scripts.instructions.md) | Any `.sh` file is present or shell script work is needed | Shebang, linting, output helper conventions (`die`/`success`/`info`) |

--- a/ai/global/index.md
+++ b/ai/global/index.md
@@ -30,7 +30,7 @@ Load these only when the work involves the relevant technology or context.
 | File | Load When | Covers |
 | --- | --- | --- |
 | [dotnet.instructions.md](dotnet.instructions.md) | Any `.csproj`, `.sln`, or `.slnx` file is present | Build/test, solution structure, test patterns, ValueTask, CancellationToken, NuGet audit |
-| [docker.instructions.md](docker.instructions.md) | Any `Dockerfile`, `Containerfile`, or compose file is present, or container work is needed | Docker/Podman runner detection, Dockerfile authoring, compose conventions, image security basics |
+| [docker.instructions.md](docker.instructions.md) | Any `Dockerfile`, `Containerfile`, `.dockerignore`, or compose file is present, or container work is needed | Docker/Podman runner detection, Dockerfile authoring, compose conventions, image security basics |
 | [dotnet-owned-packages.instructions.md](dotnet-owned-packages.instructions.md) | Any `.csproj`, `.sln`, or `.slnx` file is present, or a `Credfeto.*`/`FunFair.*` package is encountered | Registry of org-owned NuGet packages with source repos — never decompile these |
 | [sql.instructions.md](sql.instructions.md) | Any `.sql` file or SQL project is present | SQL linting, local DB connection, performance optimisation |
 | [shell-scripts.instructions.md](shell-scripts.instructions.md) | Any `.sh` file is present or shell script work is needed | Shebang, linting, output helper conventions (`die`/`success`/`info`) |

--- a/ai/global/index.md
+++ b/ai/global/index.md
@@ -30,6 +30,7 @@ Load these only when the work involves the relevant technology or context.
 | File | Load When | Covers |
 | --- | --- | --- |
 | [dotnet.instructions.md](dotnet.instructions.md) | Any `.csproj`, `.sln`, or `.slnx` file is present | Build/test, solution structure, test patterns, ValueTask, CancellationToken, NuGet audit |
+| [docker.instructions.md](docker.instructions.md) | Any `Dockerfile`, `Containerfile`, or compose file is present, or container work is needed | Docker/Podman runner detection, Dockerfile authoring, compose conventions, image security basics |
 | [dotnet-owned-packages.instructions.md](dotnet-owned-packages.instructions.md) | Any `.csproj`, `.sln`, or `.slnx` file is present, or a `Credfeto.*`/`FunFair.*` package is encountered | Registry of org-owned NuGet packages with source repos — never decompile these |
 | [sql.instructions.md](sql.instructions.md) | Any `.sql` file or SQL project is present | SQL linting, local DB connection, performance optimisation |
 | [shell-scripts.instructions.md](shell-scripts.instructions.md) | Any `.sh` file is present or shell script work is needed | Shebang, linting, output helper conventions (`die`/`success`/`info`) |


### PR DESCRIPTION
## Summary
- Adds `ai/global/docker.instructions.md`: container runner detection (Docker vs Podman), Dockerfile authoring conventions, compose conventions, and image security basics.
- Registers the new file in `ai/global/index.md` under "Load When Applicable".

## Test plan
- [x] Pre-commit hooks (markdownlint, etc.) passed locally.