### PR TITLE
fix: wire the Pre-Work Baseline Check into the routing table and Orchestrator flow

### DIFF
--- a/ai/global/agent-roles.instructions.md
+++ b/ai/global/agent-roles.instructions.md
@@ -16,6 +16,8 @@ Load when acting as a named agent. Routing table and model selection: [task-work
 
 When picking up an **Issue** that has no existing PR:
 
+0. Run the [Pre-Work Baseline Check](git.instructions.md#pre-work-baseline-check-mandatory-before-starting-any-work) before anything else in this flow — including before checking for an existing plan comment. Follow its auto-fix/failure/block rules there; only continue to step 1 once the baseline is clean.
+
 1. Check whether you have already posted a plan comment:
 
    ```bash

--- a/ai/global/git.instructions.md
+++ b/ai/global/git.instructions.md
@@ -12,15 +12,15 @@ If the environment is too broken to work in without first fixing infrastructure 
 
 ## Pre-Work Baseline Check (MANDATORY before starting any work)
 
-Before starting any work on an issue or PR, run the pre-commit hooks against all tracked files to verify the repo is clean:
+Before starting any work on an issue or PR, run the hook against every tracked file to verify the repo is clean. Resolve `<hooks-path>` using the same `core.hooksPath` scope lookup as [Pre-Commit Hook Verification](#pre-commit-hook-verification-mandatory-before-blocking) below:
 
 ```bash
-pre-commit run --all-files
+<hooks-path>/pre-commit --all-files
 ```
 
-1. If hooks **auto-fix** files (e.g. trailing whitespace, end-of-file): commit those fixes separately before starting the original work.
-2. If hooks **fail** with errors that require manual fixes: fix and commit them first, then proceed with the original work.
-3. If hooks **still fail** after all fixing attempts:
+1. If the check **auto-fixes** files (e.g. trailing whitespace, end-of-file) and everything else passes: commit those fixes on a **new, dedicated branch and issue** — a clean base-point, kept separate from the branch/issue for the requested work — and mark the original work item `Blocked` until the base-fix branch is merged. Do not start the requested work on top of an unmerged, auto-mutated baseline.
+2. If the check **fails** with errors that require manual fixes: fix and commit them first, then proceed with the original work.
+3. If the check **still fails** after all fixing attempts:
    - For an issue: comment on the issue, label it `Blocked`, and do not start work.
    - For a PR: comment on the PR, label it `Blocked`, and do not continue work.
 

--- a/ai/global/task-workflow.instructions.md
+++ b/ai/global/task-workflow.instructions.md
@@ -260,15 +260,17 @@ Mechanical agents must not interpret or fix failures. When a check fails: captur
 
 Standard loop pattern: Code Writer/Fixer loops ≤5 with Code Tester; Code Reviewer loops ≤5 re-running both each round. Code Writer, Code Fixer, Code Reviewer, and CI Debugger may invoke Coding Researcher on demand at any point when the knowledge to implement or fix is lacking — this does not count toward the standard loop limits, but each calling role may invoke Coding Researcher at most 3 times per work item. Before invoking, the calling role checks the work item's issue/PR for an existing `### Coding Researcher` comment answering the same question and reuses it if found — reused findings do not count toward the cap. After Coding Researcher returns, the calling role records the question and outcome as a `### Coding Researcher` comment on the issue/PR so it can be reused. On reaching the cap, or if Coding Researcher returns **Not possible**, the calling role stops and escalates to Orchestrator rather than continuing the loop or guessing.
 
+Every sequence below starts with the [Pre-Work Baseline Check](git.instructions.md#pre-work-baseline-check-mandatory-before-starting-any-work) — it is step 0, not merely a standalone rule, and must actually run before the first agent in the row is invoked.
+
 | Work type | Agent sequence |
 | --- | --- |
-| New feature / bug fix / refactor | Code Writer → Code Tester → Code Reviewer → Changelog → Committer → PR Submitter → CI Monitor |
-| `CHANGES_REQUESTED` on existing PR, or verbal/chat request for changes on an open PR | Code Fixer (respond to every comment) → Code Tester → Code Reviewer → Changelog → Committer → PR Submitter → CI Monitor |
-| Coverage-only task | Code Writer (tests only) → Code Tester → Code Reviewer → Changelog → Committer → PR Submitter → CI Monitor |
-| Documentation-only | Code Writer (docs only) → PR Submitter |
-| Rebase requested | Rebase Agent → PR Submitter |
-| CI failure (unknown cause) | CI Debugger |
-| Dependabot / dependency update | Dependency Updater |
+| New feature / bug fix / refactor | Pre-Work Baseline Check → Code Writer → Code Tester → Code Reviewer → Changelog → Committer → PR Submitter → CI Monitor |
+| `CHANGES_REQUESTED` on existing PR, or verbal/chat request for changes on an open PR | Pre-Work Baseline Check → Code Fixer (respond to every comment) → Code Tester → Code Reviewer → Changelog → Committer → PR Submitter → CI Monitor |
+| Coverage-only task | Pre-Work Baseline Check → Code Writer (tests only) → Code Tester → Code Reviewer → Changelog → Committer → PR Submitter → CI Monitor |
+| Documentation-only | Pre-Work Baseline Check → Code Writer (docs only) → PR Submitter |
+| Rebase requested | Pre-Work Baseline Check → Rebase Agent → PR Submitter |
+| CI failure (unknown cause) | Pre-Work Baseline Check → CI Debugger |
+| Dependabot / dependency update | Pre-Work Baseline Check → Dependency Updater |
 
 For detailed agent role definitions, see [agent-roles.instructions.md](agent-roles.instructions.md).
 


### PR DESCRIPTION
## Summary

- `task-workflow.instructions.md`: prepends "Pre-Work Baseline Check" as step 0 to every row of the Work type / Agent sequence routing table, so it's actually scheduled rather than merely documented.
- `agent-roles.instructions.md`: prepends the same step 0 to the Orchestrator's "Issue Workflow — Plan First" flow, before the existing plan-comment check.
- `git.instructions.md`: replaces the non-functional `pre-commit run --all-files` (fails — no `.pre-commit-config.yaml` at repo root; the real hook is a `core.hooksPath` wrapper) with `<hooks-path>/pre-commit --all-files`, now that `credfeto-global-pre-commit#175`/#177 has shipped that mode. Tightens the auto-fix handling: fixes now go on a new dedicated branch/issue (a clean base-point) with the original work marked `Blocked` until it merges, rather than "commit separately" with no branch/block specified.

Closes #960

## Test plan

- [x] Dry-ran `<hooks-path>/pre-commit --all-files` against a real `core.hooksPath` install — command runs (no `InvalidConfigError`) and correctly surfaces every category check across the whole tree.
- [x] Repo-wide grep confirms no other stale `pre-commit run --all-files` references remain.
- Found two pre-existing, unrelated failures during the dry run (yamllint on `dependabot.yml`/`FUNDING.yml`, markdownlint on `CLAUDE.md`/`CONTRIBUTING.md`) — filed separately as #963 per the new dedicated-branch rule rather than bundled here.