### PR TITLE
fix: satisfy markdownlint/yamllint on templated CLAUDE.md, CONTRIBUTING.md, and FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,3 @@
+---
 github: credfeto
 buy_me_a_coffee: mark.ridgwell

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,3 @@
+# AI Instructions
+
 Use the instructions in [AI Instructions](.ai-instructions) to do everything.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,15 +5,14 @@ First off, thanks for taking the time to contribute! ❤️
 All types of contributions are encouraged and valued. See the [Table of Contents](#table-of-contents) for different ways to help and details about how this project handles them. Please make sure to read the relevant section before making your contribution. It will make it a lot easier for us maintainers and smooth out the experience for all involved. The community looks forward to your contributions. 🎉
 
 > And if you like the project, but just don't have time to contribute, that's fine. There are other easy ways to support the project and show your appreciation, which we would also be very happy about:
+>
 > - Star the project
 > - Tweet about it
 > - Refer this project in your project's readme
 > - Mention the project at local meetups and tell your friends/colleagues
 
-
 ## Table of Contents
 
-- [Code of Conduct](#code-of-conduct)
 - [I Have a Question](#i-have-a-question)
 - [I Want To Contribute](#i-want-to-contribute)
 - [Reporting Bugs](#reporting-bugs)
@@ -44,15 +43,13 @@ If you then still feel the need to ask a question and need clarification, we rec
 
 We will then take care of the issue as soon as possible.
 
-
-
 ## I Want To Contribute
 
 > ### Legal Notice
+>
 > When contributing to this project, you must agree that you have authored 100% of the content, that you have the necessary rights to the content and that the content you contribute may be provided under the project license.
 
 ### Reporting Bugs
-
 
 #### Before Submitting a Bug Report
 
@@ -69,11 +66,9 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 - Possibly your input and the output
 - Can you reliably reproduce the issue? And can you also reproduce it with older versions?
 
-
 #### How Do I Submit a Good Bug Report?
 
 > You must never report security related issues, vulnerabilities or bugs including sensitive information to the issue tracker, or elsewhere in public. Instead, sensitive bugs must be sent following the instructions in the [SECURITY](SECURITY.md) document.
-
 
 We use GitHub issues to track bugs and errors. If you run into an issue with the project:
 
@@ -86,12 +81,11 @@ Once it's filed:
 
 - The project team will label the issue accordingly.
 - A team member will try to reproduce the issue with your provided steps. If there are no reproduction steps or no obvious way to reproduce the issue, the team will ask you for those steps and mark the issue as `needs-repro`. Bugs with the `needs-repro` tag will not be addressed until they are reproduced.
-- If the team is able to reproduce the issue, it will be marked `needs-fix`, as well as possibly other tags (such as `critical`), and the issue will be left to be [implemented by someone](#your-first-code-contribution).
+- If the team is able to reproduce the issue, it will be marked `needs-fix`, as well as possibly other tags (such as `critical`), and the issue will be left to be implemented by someone.
 
 ### Suggesting Enhancements
 
 This section guides you through submitting an enhancement suggestion for CONTRIBUTING.md, **including completely new features and minor improvements to existing functionality**. Following these guidelines will help maintainers and the community to understand your suggestion and find related suggestions.
-
 
 #### Before Submitting an Enhancement
 
@@ -99,7 +93,6 @@ This section guides you through submitting an enhancement suggestion for CONTRIB
 <!-- - Read the [documentation]() carefully and find out if the functionality is already covered, maybe by an individual configuration. -->
 - Perform a [search](/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
 - Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this feature. Keep in mind that we want features that will be useful to the majority of our users and not just a small subset. If you're just targeting a minority of users, consider writing an add-on/plugin library.
-
 
 #### How Do I Submit a Good Enhancement Suggestion?
 
@@ -112,4 +105,5 @@ Enhancement suggestions are tracked as [GitHub issues](/issues).
 - **Explain why this enhancement would be useful** to most CONTRIBUTING.md users. You may also want to point out the other projects that solved it better and which could serve as inspiration.
 
 ## Attribution
+
 This guide is based on the **contributing.md**. [Make your own](https://contributing.md/)!


### PR DESCRIPTION
## Summary
- `CLAUDE.md`: add a top-level heading (MD041)
- `CONTRIBUTING.md`: fix stray double-blank-lines (MD012), headings not surrounded by blank lines (MD022), a list not surrounded by blank lines inside a blockquote (MD032), and two link fragments pointing at headings that don't exist in this file (MD051)
- `.github/FUNDING.yml`: add the required YAML document-start marker

These three files are copied verbatim into every repo templated from `cs-template`. Running `credfeto-global-pre-commit`'s baseline check (`--all-files`) against `credfeto-orchestrator` surfaced these as pre-existing failures — fixing them here means every consuming repo inherits clean copies instead of re-discovering the same lint errors independently.

`.github/dependabot.yml` has the same document-start/indentation issue but is deliberately left alone — consuming repos customise its ecosystem list rather than keeping it verbatim, so fixing it is a separate change.

## Test plan
- [x] Ran `sh .../credfeto-global-pre-commit/src/hooks/pre-commit --all-files` against this repo before and after — markdownlint and yamllint (for the three touched files) now pass
- [x] Local commit went through this repo's own pre-commit hook cleanly