### PR TITLE
docs(ai): require checking inline PR review comments in Code Fixer role

### DIFF
--- a/ai/global/agent-roles.instructions.md
+++ b/ai/global/agent-roles.instructions.md
@@ -213,7 +213,7 @@ The same rule applies when picking up an **issue**: if any comment on that issue
 
 ### Comment Replies (MANDATORY)
 
-Reply to every PR or issue comment that prompted an action:
+Reply to every PR or issue comment that prompted an action. "Every PR or issue comment" spans both comment surfaces: top-level PR/issue comments and review summaries (`gh pr view <n> --json comments,reviews`) **and** inline/diff-level review comments (`gh api repos/<owner>/<repo>/pulls/<n>/comments`) — a review can carry an empty top-level body with the actual feedback only in an inline comment, so both must be checked before concluding there is nothing to reply to.
 
 - Code change made: reply with `Fixed in <commit-sha> — <one sentence describing what changed and why>`.
 - Question answered inline (no code change): reply with the full answer.
@@ -397,6 +397,7 @@ Invoked by: Code Writer, Code Fixer, Code Reviewer, CI Debugger.
 ## Code Fixer
 
 - Address requested changes on an existing PR — this includes both GitHub `CHANGES_REQUESTED` review status and verbal/chat requests for changes on an open PR.
+- Fetch **both** comment surfaces before deciding there is nothing to address: top-level PR comments and review summaries (`gh pr view <n> --repo <owner/repo> --json comments,reviews,reviewDecision`) **and** inline/diff-level review comments (`gh api repos/<owner>/<repo>/pulls/<n>/comments`). A reviewer can submit a `CHANGES_REQUESTED` review with an empty top-level summary and put their actual feedback only in an inline diff comment — the review decision alone is enough to treat the PR as having unaddressed work, and the inline-comment endpoint is the only place its content is visible.
 - If a fix requires knowledge outside the instruction files, invoke Coding Researcher first — do not guess or fabricate. If Coding Researcher returns **Not possible**, stop and escalate to Orchestrator with the explanation; do not partially apply the fix.
 - Convert to draft before starting (`gh pr ready <number> --undo`).
 - One commit per review comment. Hand off to Code Tester after each fix.


### PR DESCRIPTION
## Summary
- `gh pr view --json comments,reviews` only surfaces top-level issue comments and a review's own top-level summary — it never returns inline/diff-level review comments, which live solely on `gh api repos/<owner>/<repo>/pulls/<n>/comments`.
- A reviewer can submit a `CHANGES_REQUESTED` review with an empty top-level body and put their actual feedback only in an inline diff comment; the automation then idles out to a `Blocked` label even though a human had already responded.
- Adds a bullet to the **Code Fixer** section of `ai/global/agent-roles.instructions.md` requiring both comment surfaces to be fetched before deciding there is nothing to address, and extends the **Comment Replies (MANDATORY)** section so its "every comment" scope explicitly covers both object models.

## Test plan
- [x] Documentation-only change — no `.cs`/`.csproj`/build-affecting files touched.
- [x] Ran the pre-commit baseline hook (`<hooks-path>/pre-commit --all-files`) before committing — passed clean.
- [x] Proofread the new wording against the existing style/terminology in `github-cli.instructions.md`'s "Inline PR Review Comments via `gh api`" section.

Closes #945