### PR TITLE
chore: extract rebasing rules into git-rebasing.instructions.md

### DIFF
--- a/ai/global/agent-roles.instructions.md
+++ b/ai/global/agent-roles.instructions.md
@@ -409,7 +409,7 @@ Invoked by: Code Writer, Code Fixer, Code Reviewer, CI Debugger.
 
 - Rebase the named branch onto `origin/main`.
 - CHANGELOG conflicts: keep entries from both sides.
-- Version conflicts in dependency manifests, action pins, or runtime versions: take the latest secure candidate per [git.instructions.md](git.instructions.md#resolving-version-conflicts-when-merging-or-rebasing). If the chosen version breaks the build, report to Orchestrator; fixing build breakage is not the Rebase Agent's job.
+- Version conflicts in dependency manifests, action pins, or runtime versions: take the latest secure candidate per [git-rebasing.instructions.md](git-rebasing.instructions.md#resolving-version-conflicts-when-merging-or-rebasing). If the chosen version breaks the build, report to Orchestrator; fixing build breakage is not the Rebase Agent's job.
 - Any other conflict: report verbatim to Orchestrator; do not resolve.
 - Force-push with `--force-with-lease` only after all conflicts are resolved.
 

--- a/ai/global/git-rebasing.instructions.md
+++ b/ai/global/git-rebasing.instructions.md
@@ -1,0 +1,31 @@
+# Git Rebasing Instructions
+
+[Back to Global Instructions Index](index.md)
+
+## When to Rebase
+
+If already on the correct, existing work branch for this task (i.e. resuming work rather than branching fresh from `main`), bring it up to date **before** running the [Pre-Commit Hook Verification](git.instructions.md#pre-commit-hook-verification-mandatory-before-blocking) baseline check, as three distinct, ordered steps:
+
+1. **Fetch**: `git -C <repodir> fetch origin main`; always fetch first, regardless of whether a rebase turns out to be needed.
+2. **Check**: `git -C <repodir> rev-list --count HEAD..origin/main`; a non-zero count means `origin/main` has advanced and a rebase is needed.
+3. **Rebase**: only if step 2 found new commits, rebase onto `origin/main` now, following [Resolving Version Conflicts When Merging or Rebasing](#resolving-version-conflicts-when-merging-or-rebasing) below. Run the build and tests once the rebase completes.
+
+A branch just created fresh from an up-to-date `main` doesn't need this; it starts current by construction.
+
+## Resolving Version Conflicts When Merging or Rebasing
+
+When a merge or rebase produces conflicting versions of the same package, action, or runtime (both branches changed the version), resolve each conflicting entry individually; never take a whole file wholesale from one side.
+
+This applies to every version-bearing file, including:
+
+- Dependency manifests: `.csproj`, `Directory.Packages.props`, `packages.config`, `package.json`, `requirements.txt`
+- GitHub Actions `uses:` version pins in workflows and composite actions
+- Runtime and tool versions: .NET SDK (`global.json`), `dotnet-tools.json`, Node.js (`.nvmrc`, `engines`, `setup-node` versions), Python (`.python-version`, `setup-python` versions), and similar
+
+Rules:
+
+1. Take the **latest** of the candidate versions.
+2. **Security exception**: if the latest candidate is known to be less secure than another candidate (e.g. it has a published security advisory that the other does not), take the most recent candidate that is not affected.
+3. Never resolve by downgrading below every candidate, and never invent a version that appears on neither side.
+4. Lock files (`package-lock.json` and similar): do not hand-merge; resolve the manifest first, then regenerate the lock file with the package manager.
+5. After the merge or rebase completes, run the build and tests. If the chosen version broke the build (API changes, removed features), fix the breakage on the same branch as part of the merge work; do not downgrade to avoid the fix.

--- a/ai/global/git.instructions.md
+++ b/ai/global/git.instructions.md
@@ -12,13 +12,7 @@ If the environment is too broken to work in without first fixing infrastructure 
 
 ## Pre-Work Baseline Check (MANDATORY before starting any work)
 
-If already on the correct, existing work branch for this task (i.e. resuming work rather than branching fresh from `main`), bring it up to date **before** running the baseline hook below, as three distinct, ordered steps:
-
-1. **Fetch**: `git -C <repodir> fetch origin main`; always fetch first, regardless of whether a rebase turns out to be needed.
-2. **Check**: `git -C <repodir> rev-list --count HEAD..origin/main`; a non-zero count means `origin/main` has advanced and a rebase is needed.
-3. **Rebase**: only if step 2 found new commits, rebase onto `origin/main` now, following [Resolving Version Conflicts When Merging or Rebasing](#resolving-version-conflicts-when-merging-or-rebasing) below. Run the build and tests once the rebase completes.
-
-A branch just created fresh from an up-to-date `main` doesn't need this; it starts current by construction.
+If already on the correct, existing work branch for this task (i.e. resuming work rather than branching fresh from `main`), bring it up to date **before** running the baseline hook below; see [When to Rebase](git-rebasing.instructions.md#when-to-rebase) for the fetch/check/rebase procedure.
 
 Then, before starting any work on an issue or PR, run the hook against every tracked file to verify the repo is clean. Resolve `<hooks-path>` using the same `core.hooksPath` scope lookup as [Pre-Commit Hook Verification](#pre-commit-hook-verification-mandatory-before-blocking) below:
 
@@ -99,25 +93,7 @@ For full `GH_HOST` proxy behaviour and the required `gh pr create` flags, see [g
 - All new work must be in a branch; never commit directly to `main`.
 - Ensure `main` is up-to-date with `origin` before starting.
 - Continue in the same branch until the task changes.
-- Before continuing work on an existing branch, check if `origin/main` has advanced; if so, rebase first. This is done as part of the [Pre-Work Baseline Check](#pre-work-baseline-check-mandatory-before-starting-any-work) above, before the baseline hook runs.
-
-## Resolving Version Conflicts When Merging or Rebasing
-
-When a merge or rebase produces conflicting versions of the same package, action, or runtime (both branches changed the version), resolve each conflicting entry individually; never take a whole file wholesale from one side.
-
-This applies to every version-bearing file, including:
-
-- Dependency manifests: `.csproj`, `Directory.Packages.props`, `packages.config`, `package.json`, `requirements.txt`
-- GitHub Actions `uses:` version pins in workflows and composite actions
-- Runtime and tool versions: .NET SDK (`global.json`), `dotnet-tools.json`, Node.js (`.nvmrc`, `engines`, `setup-node` versions), Python (`.python-version`, `setup-python` versions), and similar
-
-Rules:
-
-1. Take the **latest** of the candidate versions.
-2. **Security exception**: if the latest candidate is known to be less secure than another candidate (e.g. it has a published security advisory that the other does not), take the most recent candidate that is not affected.
-3. Never resolve by downgrading below every candidate, and never invent a version that appears on neither side.
-4. Lock files (`package-lock.json` and similar): do not hand-merge; resolve the manifest first, then regenerate the lock file with the package manager.
-5. After the merge or rebase completes, run the build and tests. If the chosen version broke the build (API changes, removed features), fix the breakage on the same branch as part of the merge work; do not downgrade to avoid the fix.
+- Before continuing work on an existing branch, check if `origin/main` has advanced; if so, rebase first. This is done as part of the [Pre-Work Baseline Check](#pre-work-baseline-check-mandatory-before-starting-any-work) above, before the baseline hook runs; see [git-rebasing.instructions.md](git-rebasing.instructions.md) for the rebase procedure and version-conflict resolution.
 
 ## Pushing Branches
 

--- a/ai/global/github-workflows.instructions.md
+++ b/ai/global/github-workflows.instructions.md
@@ -77,7 +77,7 @@ This preference is opportunistic: switch a `uses:` line to SHA pinning when you 
 
 Resolve a tag to its commit SHA with `gh api repos/<owner>/<action>/commits/<tag> --jq '.sha'`.
 
-When a merge or rebase produces conflicting pins for the same action (or for runtime versions such as `setup-node`/`setup-dotnet` versions), take the latest secure candidate: see [git.instructions.md](git.instructions.md#resolving-version-conflicts-when-merging-or-rebasing).
+When a merge or rebase produces conflicting pins for the same action (or for runtime versions such as `setup-node`/`setup-dotnet` versions), take the latest secure candidate: see [git-rebasing.instructions.md](git-rebasing.instructions.md#resolving-version-conflicts-when-merging-or-rebasing).
 
 ## Keeping Actions Up to Date
 

--- a/ai/global/index.md
+++ b/ai/global/index.md
@@ -14,7 +14,8 @@ Read all of these before starting any task, regardless of language or context.
 
 | File | Covers |
 | --- | --- |
-| [git.instructions.md](git.instructions.md) | Prerequisites, build/test verification, git identity/GPG, branching, version-conflict merge resolution, commits, GitHub issues |
+| [git.instructions.md](git.instructions.md) | Prerequisites, build/test verification, git identity/GPG, branching, commits, GitHub issues |
+| [git-rebasing.instructions.md](git-rebasing.instructions.md) | When to rebase (fetch/check/rebase), version-conflict resolution when merging or rebasing |
 | [task-workflow.instructions.md](task-workflow.instructions.md) | Agent routing table, model selection, failure handling, issue/PR assignment, commit cadence, resuming work, command timeouts, ad-hoc prompt intake, prompt traceability |
 | [code-quality.instructions.md](code-quality.instructions.md) | Code coverage, tests, async, immutability, parameterised tests, refactoring |
 | [documentation.instructions.md](documentation.instructions.md) | README, CHANGELOG conventions |

--- a/ai/global/npm.instructions.md
+++ b/ai/global/npm.instructions.md
@@ -12,4 +12,4 @@
 - Do not use `*`, `latest`, or any semver range expressions.
 - Updates to existing packages must be **explicit and intentional**: specify the target version directly rather than relying on range resolution.
 - When updating a package, update only that package (and its required peer dependencies); do not allow transitive upgrades to pull in unreviewed version changes.
-- When a merge or rebase produces conflicting versions of the same package, take the latest secure candidate and regenerate `package-lock.json` rather than hand-merging it; see [git.instructions.md](git.instructions.md#resolving-version-conflicts-when-merging-or-rebasing).
+- When a merge or rebase produces conflicting versions of the same package, take the latest secure candidate and regenerate `package-lock.json` rather than hand-merging it; see [git-rebasing.instructions.md](git-rebasing.instructions.md#resolving-version-conflicts-when-merging-or-rebasing).

--- a/ai/global/packages.instructions.md
+++ b/ai/global/packages.instructions.md
@@ -3,7 +3,7 @@
 [Back to Global Instructions Index](index.md)
 
 - Use only secure package versions; see [security.instructions.md](security.instructions.md#dependency-vulnerability-scanning).
-- When a merge or rebase produces conflicting versions of the same package, take the latest secure candidate and fix any resulting build issues; see [git.instructions.md](git.instructions.md#resolving-version-conflicts-when-merging-or-rebasing).
+- When a merge or rebase produces conflicting versions of the same package, take the latest secure candidate and fix any resulting build issues; see [git-rebasing.instructions.md](git-rebasing.instructions.md#resolving-version-conflicts-when-merging-or-rebasing).
 - In managed languages (.NET, JVM, Python), prefer managed libraries over native; only use native if it is the most actively maintained and stable option.
 - Avoid deprecated or obsolete packages and language features; if unavoidable, add a comment explaining why and when it can be removed.
 - Prefer the standard library; where insufficient, use well-known actively-maintained third-party libraries.


### PR DESCRIPTION
## Summary
- Extracts the "when to rebase" trigger logic and the "Resolving Version Conflicts When Merging or Rebasing" section out of `git.instructions.md` into a new dedicated `ai/global/git-rebasing.instructions.md`.
- Repoints all cross-references (`index.md`, `github-workflows.instructions.md`, `agent-roles.instructions.md`, `packages.instructions.md`, `npm.instructions.md`) at the new file.
- Pure reorganisation: no rule content or behaviour change.

Closes #979

## Test plan
- [x] Ran the pre-commit hook (`markdownlint` etc.) against the changed files; all passed.
- [x] Grepped for stale `git.instructions.md#resolving-version-conflicts` anchor references; none remain.