### PR TITLE
feat: invoke /simplify in the AI Review Loop before /code-review

### DIFF
--- a/ai/global/agent-roles.instructions.md
+++ b/ai/global/agent-roles.instructions.md
@@ -70,7 +70,7 @@ After all code changes are pushed and all required CI checks pass, **before** en
 1. Update Workflow board to **AI Review** (if board data is present in your CLAUDE.md).
 2. Run: `/simplify` against the diff. It applies reuse, simplification, efficiency, and altitude cleanups directly rather than just reporting them.
 3. If `/simplify` changed any files: commit and push them.
-4. Run: `/code-review --comment`
+4. Run: `/code-review --comment`. This intentionally re-covers the reuse/simplification/efficiency categories `/simplify` already applied: `/simplify` fixes silently in step 2-3, and this step verifies nothing was missed and separately checks correctness/security/compliance, which `/simplify` does not. Expect step 4 to usually find nothing in the categories step 2 already handled.
 5. If inline PR comment findings were posted: fix each in its own commit, push, return to step 4.
 6. After `MAX_REVIEW_ITERATIONS` rounds with unresolved findings: post a PR comment listing them, add `Blocked` label, and **STOP**:
 

--- a/ai/global/agent-roles.instructions.md
+++ b/ai/global/agent-roles.instructions.md
@@ -65,29 +65,35 @@ When picking up an **Issue** that has no existing PR:
 
 After all code changes are pushed and all required CI checks pass, **before** enabling auto-merge:
 
-#### Phase A: Code review (up to `MAX_REVIEW_ITERATIONS` rounds)
+#### Phase A: Simplify (up to `MAX_REVIEW_ITERATIONS` rounds)
+
+1. Update Workflow board to **AI Simplify** (if board data is present in your CLAUDE.md).
+2. Run: `/simplify` against the diff. It applies reuse, simplification, efficiency, and altitude cleanups directly rather than just reporting them.
+3. If `/simplify` changed any files: commit and push them, then return to step 2 to re-run against the resulting diff.
+4. Once `/simplify` makes no further changes: proceed to Phase B.
+5. After `MAX_REVIEW_ITERATIONS` rounds where `/simplify` still keeps changing files (not converging): post a PR comment explaining that simplify is not converging, add `Blocked` label, and **STOP**.
+
+#### Phase B: Code review (up to `MAX_REVIEW_ITERATIONS` rounds)
 
 1. Update Workflow board to **AI Review** (if board data is present in your CLAUDE.md).
-2. Run: `/simplify` against the diff. It applies reuse, simplification, efficiency, and altitude cleanups directly rather than just reporting them.
-3. If `/simplify` changed any files: commit and push them.
-4. Run: `/code-review --comment`. This intentionally re-covers the reuse/simplification/efficiency categories `/simplify` already applied: `/simplify` fixes silently in step 2-3, and this step verifies nothing was missed and separately checks correctness, which `/simplify` does not (security and compliance are not covered by either command; they remain Phase B's job). Expect step 4 to usually find nothing in the reuse/simplification/efficiency categories step 2 already handled.
-5. If inline PR comment findings were posted: fix each in its own commit, push, return to step 4.
-6. After `MAX_REVIEW_ITERATIONS` rounds with unresolved findings: post a PR comment listing them, add `Blocked` label, and **STOP**:
+2. Run: `/code-review --comment`. This intentionally re-covers the reuse/simplification/efficiency categories Phase A's `/simplify` already applied: `/simplify` fixes silently, and this step verifies nothing was missed and separately checks correctness, which `/simplify` does not (security and compliance are not covered by either command; they remain Phase C's job). Expect step 2 to usually find nothing in the reuse/simplification/efficiency categories Phase A already handled.
+3. If inline PR comment findings were posted: fix each in its own commit, push, return to step 2.
+4. After `MAX_REVIEW_ITERATIONS` rounds with unresolved findings: post a PR comment listing them, add `Blocked` label, and **STOP**:
 
    ```bash
    gh pr edit <number> --repo <owner/repo> --add-label Blocked
    ```
 
-#### Phase B: Security review (up to `MAX_REVIEW_ITERATIONS` rounds)
+#### Phase C: Security review (up to `MAX_REVIEW_ITERATIONS` rounds)
 
 1. Update Workflow board to **AI Security Review** (if board data present).
 2. Run: `/security-review`
 3. If findings are reported (inline or in output): post them as a PR comment if not already inline, fix each in its own commit, push, return to step 2.
 4. After `MAX_REVIEW_ITERATIONS` rounds with unresolved findings: post a PR comment, add `Blocked` label, **STOP**.
 
-#### Phase C: Mark ready
+#### Phase D: Mark ready
 
-Only when both reviews pass (or no reviewable changes):
+Only when all three phases pass (or no reviewable changes):
 
 1. Update Workflow board to **Human Review** (if board data present).
 2. Enable auto-merge:
@@ -110,6 +116,7 @@ Workflow board (see agent-roles.instructions.md for update commands):
   WF_PLANNING=<option-id>
   WF_APPROVED=<option-id>
   WF_DEVELOPMENT=<option-id>
+  WF_AI_SIMPLIFY=<option-id>
   WF_AI_REVIEW=<option-id>
   WF_AI_SECURITY_REVIEW=<option-id>
   WF_HUMAN_REVIEW=<option-id>

--- a/ai/global/agent-roles.instructions.md
+++ b/ai/global/agent-roles.instructions.md
@@ -68,9 +68,11 @@ After all code changes are pushed and all required CI checks pass, **before** en
 #### Phase A: Code review (up to `MAX_REVIEW_ITERATIONS` rounds)
 
 1. Update Workflow board to **AI Review** (if board data is present in your CLAUDE.md).
-2. Run: `/code-review --comment`
-3. If inline PR comment findings were posted: fix each in its own commit, push, return to step 2.
-4. After `MAX_REVIEW_ITERATIONS` rounds with unresolved findings: post a PR comment listing them, add `Blocked` label, and **STOP**:
+2. Run: `/simplify` against the diff. It applies reuse, simplification, efficiency, and altitude cleanups directly rather than just reporting them.
+3. If `/simplify` changed any files: commit and push them.
+4. Run: `/code-review --comment`
+5. If inline PR comment findings were posted: fix each in its own commit, push, return to step 4.
+6. After `MAX_REVIEW_ITERATIONS` rounds with unresolved findings: post a PR comment listing them, add `Blocked` label, and **STOP**:
 
    ```bash
    gh pr edit <number> --repo <owner/repo> --add-label Blocked

--- a/ai/global/agent-roles.instructions.md
+++ b/ai/global/agent-roles.instructions.md
@@ -70,7 +70,7 @@ After all code changes are pushed and all required CI checks pass, **before** en
 1. Update Workflow board to **AI Review** (if board data is present in your CLAUDE.md).
 2. Run: `/simplify` against the diff. It applies reuse, simplification, efficiency, and altitude cleanups directly rather than just reporting them.
 3. If `/simplify` changed any files: commit and push them.
-4. Run: `/code-review --comment`. This intentionally re-covers the reuse/simplification/efficiency categories `/simplify` already applied: `/simplify` fixes silently in step 2-3, and this step verifies nothing was missed and separately checks correctness/security/compliance, which `/simplify` does not. Expect step 4 to usually find nothing in the categories step 2 already handled.
+4. Run: `/code-review --comment`. This intentionally re-covers the reuse/simplification/efficiency categories `/simplify` already applied: `/simplify` fixes silently in step 2-3, and this step verifies nothing was missed and separately checks correctness, which `/simplify` does not (security and compliance are not covered by either command; they remain Phase B's job). Expect step 4 to usually find nothing in the reuse/simplification/efficiency categories step 2 already handled.
 5. If inline PR comment findings were posted: fix each in its own commit, push, return to step 4.
 6. After `MAX_REVIEW_ITERATIONS` rounds with unresolved findings: post a PR comment listing them, add `Blocked` label, and **STOP**:
 


### PR DESCRIPTION
## Summary
- Adds a `/simplify` step at the start of Phase A (Code review) in the "PR Workflow: AI Review Loop" section of `ai/global/agent-roles.instructions.md`, run before `/code-review`, so reuse/simplification/efficiency/altitude cleanups are applied directly rather than just reported.
- Closes credfeto/credfeto-orchestrator#1169. Follows candidate 2 from that issue (AI Review Loop placement) per direct instruction, rather than candidate 1 (Code Writer stage).
- Companion change in `credfeto/credfeto-orchestrator`'s `oneshot` script mirrors this in its hardcoded PHASE D.

## Test plan
- [x] pre-commit hook baseline passes (markdownlint, changelog lint, etc.)
- [x] CHANGELOG.md left blank (template repo rule)