### PR TITLE
docs: document no-runtime-null-guards rule under nullable reference types

### DIFF
--- a/ai/global/dotnet.instructions.md
+++ b/ai/global/dotnet.instructions.md
@@ -441,6 +441,15 @@ When all target frameworks listed in a project file are .NET 9 or later, framewo
 - Delete any source files that exist solely as pre-.NET 9 fallback implementations (e.g. files named `*.net6.cs` or `*SourceGenerated.net6.cs` containing a `new Regex(...)` fallback for the `[GeneratedRegex]` source generator).
 - After removing the conditional blocks, verify the project still builds and all tests still pass; treat this as a separate commit from any feature or fix work.
 
+## Nullable Reference Types (MANDATORY)
+
+`<Nullable>enable</Nullable>` is a project-wide requirement for all code in this repo (enforced by `FunFair.BuildCheck`'s `Nullable` policy) and warnings are errors (see [Warning Suppression and Errors](#warning-suppression-and-errors) below). Every caller of every member, public or otherwise, is therefore itself built under `#nullable enable`: a caller passing null into a non-nullable parameter is a compiler-reported bug at the call site, not a runtime condition the callee needs to defend against.
+
+- Do not add `ArgumentNullException.ThrowIfNull(...)` or hand-written null guards for parameters typed as non-nullable reference types, on any member, public, internal, or private. Reaching that check at runtime means the compiler-enforced contract was already violated; fix the call site, do not add a defensive check for it.
+- This does not relax [Input Validation](security.instructions.md#input-validation) for untrusted external input (deserialised request bodies, query strings, file contents, env vars, message queue payloads): deserialisers, reflection, and non-nullable-aware callers outside this codebase can all still produce a runtime null despite a non-nullable annotation, so those boundaries keep validating in full.
+- If a parameter's nullability is genuinely uncertain at the call site (deserialisation, an external API contract, a third-party library without nullable annotations), type it `T?` and handle the null explicitly, rather than declaring it non-nullable and adding a guard to compensate.
+- Do not widen a type or member's visibility (`private`→`internal`, `internal`→`public`) solely to make a null-argument path testable. If the only reason to reach a member from a test is to pass `null` (typically via the null-forgiving operator `!`) against a non-nullable parameter, that call is not a real scenario any compiler-checked caller can produce, so there is nothing to test; removing the guard per this section also removes the coverage obligation for that path, see [Code Coverage](code-quality.instructions.md#code-coverage).
+
 ## Warning Suppression and Errors
 
 - Every project must build with `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>`.

--- a/ai/global/index.md
+++ b/ai/global/index.md
@@ -30,7 +30,7 @@ Load these only when the work involves the relevant technology or context.
 
 | File | Load When | Covers |
 | --- | --- | --- |
-| [dotnet.instructions.md](dotnet.instructions.md) | Any `.csproj`, `.sln`, or `.slnx` file is present | Build/test, solution structure, test patterns, ValueTask, CancellationToken, NuGet audit |
+| [dotnet.instructions.md](dotnet.instructions.md) | Any `.csproj`, `.sln`, or `.slnx` file is present | Build/test, solution structure, test patterns, ValueTask, CancellationToken, nullable reference types, NuGet audit |
 | [docker.instructions.md](docker.instructions.md) | Any `Dockerfile`, `Containerfile`, `.dockerignore`, `docker-compose*.yml`, `docker-compose*.yaml`, `compose.yml`, or `compose.yaml` is present, or container work is needed | Docker/Podman runner detection, Dockerfile authoring, compose conventions, image security basics |
 | [dotnet-owned-packages.instructions.md](dotnet-owned-packages.instructions.md) | Any `.csproj`, `.sln`, or `.slnx` file is present, or a `Credfeto.*`/`FunFair.*` package is encountered | Registry of org-owned NuGet packages with source repos: never decompile these |
 | [sql.instructions.md](sql.instructions.md) | Any `.sql` file or SQL project is present | SQL linting, local DB connection, performance optimisation |


### PR DESCRIPTION
## Summary
- Since nullable is enabled repo-wide and warnings are errors, a caller violating a non-nullable parameter contract is a compiler-caught bug, not a runtime condition to defend against.
- Adds a "Nullable Reference Types (MANDATORY)" section to ai/global/dotnet.instructions.md: no ArgumentNullException.ThrowIfNull or hand-written null guards for non-nullable reference type parameters on any member (public, internal, or private); external-input boundary validation is unaffected; do not widen a member's visibility solely to make an unreachable null-argument path testable.
- Adds "nullable reference types" to the dotnet.instructions.md row in ai/global/index.md for discoverability.

Closes #987

## Test plan
- [x] Documentation-only change; no automated tests apply.
- [x] Pre-commit hook run to completion (baseline check and pre-commit hook itself), all checks passed, including a markdownlint fix for an invalid link fragment.