### PR TITLE
docs: require raised issues to be added to the repo's linked Workflow project (#997)

### DIFF
--- a/ai/global/github-cli.instructions.md
+++ b/ai/global/github-cli.instructions.md
@@ -69,6 +69,19 @@ gh issue close <number> --repo <owner>/<repo>
 gh issue reopen <number> --repo <owner>/<repo>
 ```
 
+### Adding an Issue to the Workflow Project
+
+Every issue raised must be added to the "Workflow" project linked to the repository it was raised in (see [task-workflow.instructions.md](task-workflow.instructions.md#workflow-project-board-mandatory)). Project titles are not unique across the owner, so find the project linked to the repository first; never resolve it by title with `--add-project`.
+
+```bash
+# Find the repo's linked Workflow project number
+gh api graphql -f query='query{repository(owner:"<owner>",name:"<repo>"){projectsV2(first:10){nodes{number title}}}}' \
+  --jq '.data.repository.projectsV2.nodes[] | select(.title=="Workflow") | .number'
+
+# Add the issue to it
+gh project item-add <project-number> --owner <owner> --url <issue-url>
+```
+
 ### Available JSON Fields: `gh issue view`/`gh issue list`
 
 ```text

--- a/ai/global/index.md
+++ b/ai/global/index.md
@@ -16,7 +16,7 @@ Read all of these before starting any task, regardless of language or context.
 | --- | --- |
 | [git.instructions.md](git.instructions.md) | Prerequisites, build/test verification, git identity/GPG, branching, commits, GitHub issues |
 | [git-rebasing.instructions.md](git-rebasing.instructions.md) | When to rebase (fetch/check/rebase), version-conflict resolution when merging or rebasing |
-| [task-workflow.instructions.md](task-workflow.instructions.md) | Agent routing table, model selection, failure handling, issue/PR assignment, commit cadence, resuming work, command timeouts, ad-hoc prompt intake, prompt traceability |
+| [task-workflow.instructions.md](task-workflow.instructions.md) | Agent routing table, model selection, failure handling, issue/PR assignment, Workflow project board, commit cadence, resuming work, command timeouts, ad-hoc prompt intake, prompt traceability |
 | [code-quality.instructions.md](code-quality.instructions.md) | Code coverage, tests, async, immutability, parameterised tests, refactoring |
 | [documentation.instructions.md](documentation.instructions.md) | README, CHANGELOG conventions |
 | [security.instructions.md](security.instructions.md) | No secrets in code, input validation, output sanitisation |

--- a/ai/global/task-workflow.instructions.md
+++ b/ai/global/task-workflow.instructions.md
@@ -32,6 +32,12 @@ When selecting the next issue to work on, prefer issues with higher-priority lab
 | `On-Hold` | Needs further thought or cannot be implemented yet; do not start work |
 | `Blocked` | Needs human input before work can continue; see the Orchestrator section in [agent-roles.instructions.md](agent-roles.instructions.md) |
 
+## Workflow Project Board (MANDATORY)
+
+Every issue raised, in any repository and via any flow (deliverable issues, ad-hoc intake tracking issues, AI-initiated issues, sub-issues), must be added to the "Workflow" GitHub project linked to that repository, immediately after creation.
+
+Each repository has its own linked project titled "Workflow", and many projects share that title across the owner, so never resolve the project by title alone. Discover the repository's linked project and add the issue using the commands in [github-cli.instructions.md](github-cli.instructions.md#adding-an-issue-to-the-workflow-project).
+
 ## GitHub Issue Creation (MANDATORY)
 
 When asked to create or update a GitHub issue (i.e. the issue itself is the requested deliverable):


### PR DESCRIPTION
## Summary

Adds a mandatory rule to the shared AI instructions: every issue raised, in any repository and via any flow (deliverable issues, ad-hoc intake tracking issues, AI-initiated issues, sub-issues), must be added to the "Workflow" GitHub project linked to that repository, immediately after creation.

- `ai/global/task-workflow.instructions.md` - new "Workflow Project Board (MANDATORY)" section.
- `ai/global/github-cli.instructions.md` - new "Adding an Issue to the Workflow Project" section with the `gh` commands: discover the repo's linked project via GraphQL (project titles are not unique across the owner, so never resolve by title), then `gh project item-add`.
- `ai/global/index.md` - index description updated to mention the Workflow project board.

## Test plan

Docs-only change. Pre-commit hooks (markdownlint et al.) pass. The rule was exercised for real on the tracking issue itself: #997 was added to the repo's linked Workflow project (#124) using the documented commands.

Closes #997