### PR TITLE
docs: add python.instructions.md with venv, Python 3, and code-style rules

### DIFF
--- a/ai/global/index.md
+++ b/ai/global/index.md
@@ -39,6 +39,7 @@ Load these only when the work involves the relevant technology or context.
 | [shell.firewall.instructions.md](shell.firewall.instructions.md) | Firewall rule management is needed | `firewall-cmd` rules, private network constants |
 | [github-workflows.instructions.md](github-workflows.instructions.md) | Any `.github/workflows/*.yml` file is present or being created | Action policy, composite actions, step ordering, permissions, version pinning |
 | [npm.instructions.md](npm.instructions.md) | Any `package.json` is present or npm packages are being added/updated | Exact version pinning, `--save-exact`, no semver ranges, explicit updates |
+| [python.instructions.md](python.instructions.md) | Any `pyproject.toml`, `requirements.txt`, `setup.py`, `setup.cfg`, or `.py` file is present, or Python work is needed | Virtual environment requirement, Python 2 prohibition, latest stable Python 3, idiomatic/modular/testable code style |
 | [learnings.instructions.md](learnings.instructions.md) | A memory file (`ai/global` or `ai/local`) is created or updated to record a new learning | Filing a matching human-readable issue in `credfeto/credfeto-notes` |
 | [api.instructions.md](api.instructions.md) | An HTTP API is being created or modified | `.http` test file requirements |
 | [performance.instructions.md](performance.instructions.md) | Performance-critical code is being written or optimised | Design principles, benchmarks, optimisation workflow |

--- a/ai/global/python.instructions.md
+++ b/ai/global/python.instructions.md
@@ -1,0 +1,24 @@
+# Python Instructions
+
+> Load when: any `pyproject.toml`, `requirements.txt`, `setup.py`, `setup.cfg`, or `.py` file is present, or Python work is needed.
+
+[Back to Global Instructions Index](index.md)
+
+## Virtual Environments (MANDATORY)
+
+- Every Python project must use an isolated virtual environment (e.g. `venv`, `virtualenv`, or an equivalent tool-managed environment such as `poetry` or `pipenv`); never install packages into, or otherwise modify, the system Python installation.
+- Create the virtual environment inside the project (e.g. `.venv`) and activate it before installing dependencies or running any Python command.
+- Never install packages outside an active virtual environment; never pass `--user` or `--break-system-packages` to `pip install` to bypass this.
+- Add the virtual environment directory to `.gitignore`; never commit it.
+
+## Python Version (MANDATORY)
+
+- Python 2 is prohibited: never write new Python 2 code, and never add Python 2 tooling, syntax, or dependencies to a project.
+- If Python 2 code is encountered, migrate it to Python 3 as part of the current work rather than maintaining or extending it as-is.
+- Always target the latest stable Python 3 release available at the time of writing; do not pin to an older Python 3 minor version without a specific, stated justification (e.g. a dependency or runtime constraint).
+
+## Code Style (MANDATORY)
+
+- Generated code must be **Pythonic**: follow PEP 8 and use idiomatic constructs (context managers, comprehensions, generators, dataclasses, `enumerate`/`zip`, f-strings, etc.) rather than direct translations of patterns from other languages.
+- Code must be **highly modular**: small, single-responsibility functions, classes, and modules rather than large monolithic ones.
+- Code must be written to be **easily testable and mockable**: prefer dependency injection over hard-coded globals/singletons, and keep I/O, network, and filesystem access at the edges so business logic can be tested and mocked in isolation.


### PR DESCRIPTION
## Summary
- Add `ai/global/python.instructions.md`: mandatory virtual environments (no system Python installs), Python 2 prohibited (migrate to Python 3 if encountered), always target the latest stable Python 3, and generated code must be Pythonic, highly modular, and easy to test/mock.
- Register the new file in `ai/global/index.md` under "Load When Applicable".

Closes #1004

## Test plan
- [x] Pre-commit hook run locally, all checks passed
- Documentation-only change, no build/tests otherwise apply