### PR TITLE
chore(ai): record Projects v2 write-verification and git destructive-command learnings

### DIFF
--- a/ai/global/agent-roles.instructions.md
+++ b/ai/global/agent-roles.instructions.md
@@ -159,9 +159,22 @@ gh api graphql \
   -f query='mutation($p:ID!,$i:ID!,$f:ID!,$v:String!){updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,value:{singleSelectOptionId:$v}}){projectV2Item{id}}}' \
   -f p="${WF_PROJECT_ID}" -f i="${PROJECT_ITEM_ID}" \
   -f f="${WF_STATUS_FIELD_ID}" -f v="<STATUS_OPTION_ID>" > /dev/null
+
+# Step 4: verify the write actually persisted; retry up to 3 times with backoff if not
+for attempt in 1 2 3; do
+  ACTUAL=$(gh api graphql \
+    -f query='query($i:ID!){node(id:$i){... on ProjectV2Item{fieldValues(first:50){nodes{... on ProjectV2ItemFieldSingleSelectValue{optionId field{... on ProjectV2SingleSelectField{id}}}}}}}}' \
+    -f i="${PROJECT_ITEM_ID}" \
+    --jq ".data.node.fieldValues.nodes[] | select(.field.id==\"${WF_STATUS_FIELD_ID}\") | .optionId")
+  [ "$ACTUAL" = "<STATUS_OPTION_ID>" ] && break
+  sleep "$attempt"
+done
+[ "$ACTUAL" = "<STATUS_OPTION_ID>" ] || echo "::warning::Workflow board write did not persist after 3 attempts"
 ```
 
 `addProjectV2ItemById` is idempotent: calling it again for an item already in the project just returns the existing item ID.
+
+**Step 4 is MANDATORY, not optional.** `updateProjectV2ItemFieldValue` can return success (no GraphQL error) on an item that was just added by `addProjectV2ItemById` in Step 2, without the field write actually persisting: a known eventual-consistency race in the Projects v2 API on freshly-added items. Reporting success (a log line, a `core.notice`, a status comment) without this read-back verification is a real bug that shipped and went unnoticed because nothing threw (see `funfair-tech/funfair-server-template` issue #918, fixed in PR #920, for the incident this rule is drawn from). Never skip the verification step to save a round-trip.
 
 ### On-Hold Label
 

--- a/ai/global/git.instructions.md
+++ b/ai/global/git.instructions.md
@@ -93,6 +93,10 @@ For full `GH_HOST` proxy behaviour and the required `gh pr create` flags, see [g
 - In Claude Code the `cd` form also triggers an unnecessary permission prompt for the directory change itself.
 - This applies to all git subcommands: `git -C /path status`, `git -C /path add`, `git -C /path commit`, etc.
 
+## Destructive Commands (MANDATORY)
+
+Before any command that can discard uncommitted work (`git reset --hard`, `git checkout`/`restore` over tracked files, `git clean`), run `git status` first. If it shows uncommitted changes you did not just create and intend to discard, stash them (`git stash -u`, `-u` to include untracked files) or commit them before proceeding. Running the destructive command directly on the assumption the tree is clean, without checking, has silently discarded real work in practice; the check costs one command and is never skippable "because it should be clean".
+
 ## Avoid `git worktree`
 
 - Do not use `git worktree` to create additional working trees for a repo.


### PR DESCRIPTION
## Summary

Two learnings from work on `funfair-tech/funfair-server-template` issue #918 / PR #920, captured per the Management Rules in `.ai-instructions`:

- `agent-roles.instructions.md`: the shared "Workflow board" update pattern (add item, then set its status field) can report success on a field write that never actually persisted - a known Projects v2 eventual-consistency race on items just added to a board. Adds a mandatory Step 4 that reads the field value back and retries with backoff before reporting success.
- `git.instructions.md`: adds a mandatory rule to run `git status` (and stash/commit anything found) before any command that can discard uncommitted work (`git reset --hard`, `git checkout`/`restore`, `git clean`) - a `git reset --hard` run without that check discarded uncommitted edits during this same session.

Human-readable write-ups:
- https://github.com/credfeto/credfeto-notes/issues/378
- https://github.com/credfeto/credfeto-notes/issues/379

## Test plan

- [x] Pre-commit hooks (markdownlint etc.) pass
- N/A - documentation-only change to shared AI instructions, no executable code
