### PR TITLE
docs(task-workflow): require a comment when correcting a prior issue/PR claim

### DIFF
--- a/ai/global/task-workflow.instructions.md
+++ b/ai/global/task-workflow.instructions.md
@@ -73,6 +73,14 @@ Once a request is already tracked by an issue or PR (including one just created 
 - Post this before or immediately after acting on the prompt; do not let several prompts accumulate unrecorded.
 - This applies whether the prompt arrived as a live chat message or as a GitHub comment (GitHub comments are already covered by [Comment Replies](agent-roles.instructions.md#comment-replies-mandatory)).
 
+## Correcting a Prior Claim (MANDATORY)
+
+If a factual claim or finding you previously posted in an issue/PR body or comment turns out to be wrong (e.g. a root-cause statement, an evidence point, a "this is a deviation from process" assertion), post a new comment stating the correction and briefly why, quoting or referencing the original claim being corrected. Editing the body to also fix it is fine, but the comment is the mandatory part: a silent in-place body edit is not sufficient on its own, because GitHub only surfaces it as a small "edited" marker that a human reviewer can easily miss, unlike a comment which appears in the normal timeline.
+
+This is distinct from [PR Title, Body, and Label Sync](#pr-title-body-and-label-sync-mandatory) below, which requires routine in-place edits to keep a PR's title/body/labels synced with its linked issues; that is not a correction and needs no comment. This rule is about retracting or fixing something substantive that was previously asserted as true.
+
+(Background: `credfeto/credfeto-orchestrator#1262` — an agent session silently edited its own issue body ten minutes after posting it to fix a wrong claim; the fix was accurate and nothing was destroyed since GitHub retains full edit history, but the silent edit alone made it look, at a glance, like evidence had been suppressed.)
+
 ## PR Lifecycle
 
 - Only one active branch or open PR per repository at a time; do not create another until the current one is merged and closed.


### PR DESCRIPTION
# Description

Adds a `Correcting a Prior Claim (MANDATORY)` rule to `ai/global/task-workflow.instructions.md`: correcting a previously-posted factual claim or finding on an issue/PR must be done via an appended comment, not only a silent in-place body edit, so the correction is visible in the normal timeline instead of only via GitHub's "edited" marker.

Prompted by `credfeto/credfeto-orchestrator#1262`, where an agent session silently edited its own issue body ten minutes after posting it to fix a wrong claim about changelog/PR ordering. The fix was accurate and nothing was destroyed (GitHub retains full edit history), but the silent edit alone made it look, at a glance, like evidence had been suppressed.

Scoped narrowly so it does not conflict with the existing `PR Title, Body, and Label Sync (MANDATORY)` section, which requires routine in-place body edits to keep summaries/`Closes #<n>` current - that is unaffected.

Closes #1016

## How Has This Been Tested

- [x] Manual Testing: documentation-only change; re-read against `PR Title, Body, and Label Sync`, `Prompt Traceability`, and `agent-roles.instructions.md`'s `Comment Replies` for consistency/no duplication. Ran the repo's pre-commit baseline (`--all-files`) before committing; all checks passed.

## Types of changes

- [x] Docs change

## Deployment Configuration Changes

- [ ] Requires deployment configuration changes as specified below and in CHANGELOG.md

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] Unreleased section of CHANGELOG.md has been updated with details of this PR.
- [x] No user-controlled or step-output value is string-interpolated directly into a `run:`/`script:` body (workflow or composite action); pass it via step-level `env:` and reference `$VAR` (bash) or `process.env.VAR` (github-script) instead.

Note: no `CHANGELOG.md` entry - `credfeto/cs-template` hits the template-repo changelog skip condition.