### PR TITLE
fix: clarify the Issue Approved gate does not apply once a PR already exists

### DIFF
--- a/ai/global/agent-roles.instructions.md
+++ b/ai/global/agent-roles.instructions.md
@@ -61,6 +61,8 @@ When picking up an **Issue** that has no existing PR:
    - **Board configured**: human sets board status to **Approved** and removes `Blocked`.
    - **No board**: human posts an approval comment (`approved` / `go ahead` / `looks good` / `lgtm`) and removes `Blocked`.
 
+**Scope of the Approved gate — once a PR exists, this section no longer applies.** The gate above governs only picking up an Issue that has **no existing PR**. A Pull Request is never opened for an Issue until that gate has already been passed by a human — the PR's own existence *is* the authorisation. A PR-phase session must never re-derive or re-check approval from the PR's own Workflow board card: that card is purely a phase marker for the PR Workflow below, not a second approval gate. If a PR's own card still reads "Not Started", "Planning", or "Approved" (e.g. the session that opened the draft PR died before advancing its card, or a freshly-seeded board has not caught up yet), treat that as "Development" and continue with the PR Workflow below — never block pending approval, and never treat it as evidence the linked Issue was never approved (confirmed incident: `credfeto/recommendations-defi-dashboard#412`, where a PR-phase session misread its own lagging "Not Started" card this way and blocked instead of finishing the deferred implementation — [credfeto/credfeto-orchestrator#1276](https://github.com/credfeto/credfeto-orchestrator/issues/1276)). The two cards are kept in step automatically (issue → PR, forward-only) by the orchestrator itself; this is not something a session needs to reconcile by hand.
+
 ### PR Workflow: AI Review Loop
 
 After all code changes are pushed and all required CI checks pass, **before** enabling auto-merge:

--- a/ai/global/agent-roles.instructions.md
+++ b/ai/global/agent-roles.instructions.md
@@ -482,7 +482,7 @@ Runs in two modes; both use `dotnet changelog` (see [changelog.instructions.md](
 - Update body if PR already exists. Add yourself as assignee.
 - Do **not** mark ready or enable auto-merge here; that is the Orchestrator's job after the AI review loop (see [PR Workflow: AI Review Loop](#pr-workflow-ai-review-loop)). Leave the PR as draft.
 
-## CI Monitor _(not currently enabled)_
+## CI Monitor *(not currently enabled)*
 
 - Watch checks after PR is ready: `gh pr checks <number> --watch`.
 - All pass → done. Any fail → hand off to CI Debugger. Repeat until all pass or CI Debugger escalates.


### PR DESCRIPTION
## Summary
- A PR-phase session on `recommendations-defi-dashboard#412` read its own PR's Workflow board card ("Not Started") and incorrectly fell back to the Issue-workflow's "Plan First: Approved gate", which is explicitly scoped to picking up an Issue with no existing PR.
- Adds an explicit "Scope of the Approved gate" note to `ai/global/agent-roles.instructions.md`: once a PR exists, its existence is the authorisation - a PR-phase session must never re-derive/re-check approval from the PR's own board card.
- Also fixes a pre-existing markdownlint MD049 (emphasis-style) violation in the same file that was blocking any commit touching it.
- Companion to credfeto/credfeto-orchestrator#1276, which mirrors the linked issue's board status onto the PR's own card so it never lags in the first place.

Closes #1019

## Test plan
- [x] `markdownlint` pre-commit hook passes on the changed file.
- [x] Manual re-read for internal consistency against the rest of `agent-roles.instructions.md` and against credfeto-orchestrator#1276's companion prompt-text fix.