### PR TITLE
docs(ai): PrivateTmp=yes orphans the rootless-podman pause process

### DIFF
--- a/ai/global/docker-rootless-podman-systemd.instructions.md
+++ b/ai/global/docker-rootless-podman-systemd.instructions.md
@@ -61,7 +61,7 @@
 ## `ProtectHome=yes` Breaks `XDG_RUNTIME_DIR` (MANDATORY)
 
 - `ProtectHome=yes` also masks `/run/user/*` on the unit, which breaks the D-Bus session bus fix above.
-- Fix: use `ProtectSystem=strict` + `PrivateTmp=yes` instead (both confirmed compatible with rootless podman on a real host); drop `ProtectHome`. Do **not** add `NoNewPrivileges=yes` alongside these — see the next section for why.
+- Fix: use `ProtectSystem=strict` instead; drop `ProtectHome`. Do **not** add `NoNewPrivileges=yes` alongside this — see the next section for why. Do **not** add `PrivateTmp=yes` either — see the `PrivateTmp=yes` section further down for why.
 
 ## `NoNewPrivileges=yes` Breaks `newuidmap`/`newgidmap` on Every Reboot (MANDATORY)
 
@@ -76,6 +76,15 @@
 - This only bites **after a reboot**, not on every `systemctl restart` of the unit: podman only needs to build a brand-new user namespace once per boot (the namespace does not survive a reboot), while restarts within the same boot reuse the existing one and never exec `newuidmap` again. A restart "working fine" is not evidence `NoNewPrivileges=yes` is safe — only a real reboot exercises the failing path.
 - Verify by reproducing directly rather than guessing from the unit file alone: `sudo systemd-run --property=NoNewPrivileges=yes --property=User=<svc-user> --property=Group=<svc-group> /usr/bin/newuidmap <pid-owned-by-svc-user> 0 <uid> 1` reproduces `Could not set caps`; the same command with the property removed gets past that point (reaches an unrelated failure further down, e.g. `write to uid_map failed`, which confirms the capability was actually granted this time).
 - Fix: do not set `NoNewPrivileges=yes` on a rootless-podman container-runner unit at all.
+
+## `PrivateTmp=yes` Orphans the Rootless-Podman Pause Process (MANDATORY)
+
+- Rootless podman keeps a long-lived "pause" process per UID (`/run/user/<uid>/libpod/tmp/pause.pid`, cgroup `podman-pause-*.scope`, reparented to PID 1) so it doesn't have to rebuild the user namespace on every invocation — this is the same mechanism the `NoNewPrivileges=yes` section above depends on surviving across restarts within a boot. `PrivateTmp=yes` gives every *start* of the container-runner unit its own private `/tmp` and `/var/tmp` bind mounts, torn down when that particular service instance ends.
+- If the pause process is created (or first joined) while one of those private mount namespaces is current, it keeps that namespace's view of `/var/tmp` for as long as it lives — including after the owning service instance, and its private tmp, is gone. A later `podman pull`/`podman-compose pull` that joins the same still-alive pause process then tries to create its image-copy scratch directory inside a `/var/tmp` that, from its point of view, no longer exists.
+- Symptom: `podman pull` / `podman-compose pull` (and hence the container-runner unit) fails with `creating a temporary directory: mkdir /var/tmp/container_images_storageNNNNNNNN: no such file or directory`, even though `/var/tmp` plainly exists on the host and a plain `mkdir` there (outside podman) succeeds. Nothing auto-recovers — every subsequent pull attempt fails the same way until the pause process is reset.
+- Verify: `cat /run/user/<uid>/libpod/tmp/pause.pid`, then `cat /proc/<pid>/mountinfo | grep var/tmp` — a source path containing `.../<unit-name>.service-*/tmp//deleted` confirms this cause.
+- Recovery, if it happens: confirm no containers are currently running (`podman ps -a` as the service account) before killing the pause process directly (`kill <pause-pid>`, then remove the stale pidfile) — that is only safe when nothing depends on the namespace it's holding open. If containers *are* running, use `podman system migrate` instead; it resets the pause process safely but stops all running containers as part of doing so, so it is not something to run unconditionally as an automated reactive fix on every pull failure.
+- Fix: do not set `PrivateTmp=yes` on a rootless-podman container-runner unit at all. `ProtectSystem=strict` plus explicit `ReadWritePaths` for whatever the unit actually needs to write are the accepted substitute.
 
 ## Renaming a Systemd Timer During a Migration Leaves the Old One Active (MANDATORY)
 
@@ -121,3 +130,5 @@ Use `podman compose down` instead (stop + remove in one step) rather than a `sto
 ## Source
 
 Findings captured from real-host debugging during the `credfeto-notification-bot-docker` docker-to-rootless-podman migration; see [credfeto/cs-template#978](https://github.com/credfeto/cs-template/issues/978) and credfeto/credfeto-notification-bot-docker#12 / credfeto/credfeto-notification-bot-docker#14 / credfeto/credfeto-notification-bot-docker#17 for the full narrative and exact commands used to reproduce/diagnose each one.
+
+The `PrivateTmp=yes` section was added 2026-08-06 after a real-host outage on `notifications.lan`: see credfeto/credfeto-notification-bot-docker#19.


### PR DESCRIPTION
## Summary

The `docker-rootless-podman-systemd.instructions.md` guidance previously recommended `PrivateTmp=yes` alongside `ProtectSystem=strict` as the drop-in replacement for `ProtectHome=yes`. That turned out not to be safe: rootless podman's long-lived per-UID pause process can end up bound to a private `/var/tmp` mount from one start of the unit, which a later start tears down - breaking image pulls permanently (`mkdir /var/tmp/container_images_storage...: no such file or directory`) with no automatic recovery.

Confirmed on a real host: see credfeto/credfeto-notification-bot-docker#19, which removes `PrivateTmp=yes` from that repo's unit in response to this exact failure on `notifications.lan`, 2026-08-06.

## Changes

- Corrects the `ProtectHome=yes` section to stop recommending `PrivateTmp=yes`.
- Adds a new `PrivateTmp=yes` Orphans the Rootless-Podman Pause Process section documenting the symptom, verification steps, safe recovery (and why an unconditional automated reset via `podman system migrate` is not safe - it stops all running containers), and the fix.
- Updates the Source footer.

## How Has This Been Tested

- [x] Docs-only change - no unit tests apply.
- [x] Manual testing: the underlying failure and fix were reproduced and verified live on `notifications.lan`; see credfeto/credfeto-notification-bot-docker#19 for the exact commands.

## Types of changes

- [x] Docs change

## Checklist

- [x] Unreleased section of CHANGELOG.md has been updated with details of this PR. - N/A, `cs-template` is excluded from changelog entries per its own rule.
- [x] No user-controlled or step-output value is string-interpolated directly into a `run:`/`script:` body - N/A, no workflow changes.