### PR TITLE
docs(sql): replace dead-end ad-hoc sqlcmd example with testdb wrapper guidance

### DIFF
--- a/ai/global/sql.examples.md
+++ b/ai/global/sql.examples.md
@@ -20,11 +20,12 @@ PASSWORD=<password>
 DB=Treasury
 ```
 
-Ad-hoc `sqlcmd` invocation (only needed outside `<repo>/testdb`):
-
-```sh
-. "$HOME/.database" && . .database && sqlcmd -S "$SERVER" -U "$USER" -P "$PASSWORD" -d "$DB" ...
-```
+A direct `sqlcmd` invocation may be blocked in some agent environments (e.g. to prevent
+reading `.database` credential files via a raw command line). Use `<repo>/testdb` (or an
+equivalent repo-local query wrapper script, e.g. `querydb`, if the repo has one) for ad-hoc
+queries instead: it sources both `.database` files and invokes `sqlcmd` internally as its
+own subprocess. A repo with no such wrapper script is missing one; that is a gap to raise,
+not something to route around with a direct `sqlcmd` call.
 
 ## Performance Baseline
 

--- a/ai/global/sql.instructions.md
+++ b/ai/global/sql.instructions.md
@@ -10,7 +10,7 @@ Run a SQL linter appropriate for the dialect before every commit. Refer to local
 
 ## Local Database Connection (MS SQL Server)
 
-Two `.database` files provide the local connection: see [sql.examples.md](sql.examples.md) for their contents and the recommended ad-hoc query route (`<repo>/testdb` or an equivalent wrapper).
+Two `.database` files provide the local connection: see [sql.examples.md](sql.examples.md) for their contents and the recommended ad-hoc query route (`querydb` or an equivalent wrapper).
 
 - **`$HOME/.database`**: machine-specific credentials, never committed.
 - **`<repo>/.database`**: committed, repo-specific (database name).

--- a/ai/global/sql.instructions.md
+++ b/ai/global/sql.instructions.md
@@ -10,7 +10,7 @@ Run a SQL linter appropriate for the dialect before every commit. Refer to local
 
 ## Local Database Connection (MS SQL Server)
 
-Two `.database` files provide the local connection: see [sql.examples.md](sql.examples.md) for their contents and the ad-hoc `sqlcmd` invocation.
+Two `.database` files provide the local connection: see [sql.examples.md](sql.examples.md) for their contents and the recommended ad-hoc query route (`<repo>/testdb` or an equivalent wrapper).
 
 - **`$HOME/.database`**: machine-specific credentials, never committed.
 - **`<repo>/.database`**: committed, repo-specific (database name).


### PR DESCRIPTION
## Summary

`ai/global/sql.examples.md` documented a direct `sqlcmd` invocation that is now fully
blocked by the `reject-obfuscated-commands` hook in any agent environment that installs
it, with no explanation or pointer to the sanctioned route. This replaces it with
guidance to use `<repo>/testdb` (or an equivalent repo-local wrapper) for ad-hoc queries,
and updates the `sql.instructions.md` pointer to match.

Closes #1027

## Test plan

Documentation-only change; verified via the repo's pre-commit hook chain (markdownlint /
doc-link checks) on both the staged change and the commit itself.