### PR TITLE
docs(ai): add claude-hooks.instructions.md for PreToolUse denial handling

### DIFF
--- a/ai/global/claude-hooks.instructions.md
+++ b/ai/global/claude-hooks.instructions.md
@@ -29,26 +29,18 @@ What "the specific thing" above means in practice:
 - `git commit must run with run_in_background: true` means add that tool parameter, not switch to
   a different commit approach.
 
+Fixing one hook's violation at a time and retrying can trigger a second hook's denial on the same
+call, so satisfy every applicable rule in the one call that is retried rather than discovering them
+one by one. The most common case is a command that must satisfy both a git-invocation-shape hook
+and a must-be-backgrounded hook at once: `git -C <dir> commit -m "..."` invoked with
+`run_in_background: true` set on that same tool call.
+
 ## Prefer the Tool's Own Backgrounding Parameter (MANDATORY)
 
 Use the tool's own `run_in_background: true` parameter, never shell-level backgrounding (`&`,
 `nohup ... &`, `disown`). Shell-level backgrounding is blocked outright by
-`enforce-background-for-long-running-commands` (see below) and has caused the exact
-denial-misread-as-in-flight failure described above in live incidents
-(`credfeto/credfeto-orchestrator#1281`).
-
-## Satisfy Every Applicable Hook in the Same Retry
-
-Satisfying each hook's rule individually by trial and error (fix one, get denied by the other, fix
-that, and so on) is what several live incidents show agents doing; instead, satisfy every
-applicable rule in the one call that is retried. The most common case is a command that must
-satisfy both a git-invocation-shape hook and a must-be-backgrounded hook at once:
-
-```text
-git -C <dir> commit -m "..."
-```
-
-invoked with `run_in_background: true` set on that same tool call.
+`enforce-background-for-long-running-commands` (see below) and produces the same
+denial-misread-as-in-flight failure described above.
 
 ## Reference: Installed Hook Set
 
@@ -57,7 +49,7 @@ this file was written:
 
 | Hook | Blocks | Why |
 | --- | --- | --- |
-| `reject-obfuscated-commands` | Any Bash command not built from plain, obviously-spelled command words (indirect execution, sub-shells, wrapper-flag smuggling) | Text/regex scanning for banned patterns is an arms race that never converges (eight bypass rounds found in the prior hand-rolled approach: `credfeto/cs-template#1159`/`#1105`); this hook parses with a real shell parser and applies policy to the resulting AST instead. Reads `command-allowlist`, `command-blocklist`, and `env-var-blocklist` as its data tables. |
+| `reject-obfuscated-commands` | Any Bash command not built from plain, obviously-spelled command words (indirect execution, sub-shells, wrapper-flag smuggling) | Text/regex scanning for banned patterns is an arms race that never converges against a determined bypass attempt; this hook parses with a real shell parser and applies policy to the resulting AST instead. Reads `command-allowlist`, `command-blocklist`, and `env-var-blocklist` as its data tables. |
 | `command-allowlist` (data file, not a hook) | N/A | Known-good command names for `reject-obfuscated-commands`; a command not on this list (and not on `command-blocklist`, which wins) is rejected outright. |
 | `command-blocklist` (data file, not a hook) | N/A | Known-bad command names for `reject-obfuscated-commands` (e.g. `eval`, `source`, `bash`) that are rejected even though they are plain bare words, because each one hides or re-enters execution in a way this check cannot see through. |
 | `env-var-blocklist` (data file, not a hook) | N/A | Environment variables (`PATH`, `IFS`, `LD_PRELOAD`, `GIT_*`, and similar) that `reject-obfuscated-commands` refuses to let a command assign, because they change how *other* commands are located, parsed, or attributed. |

--- a/ai/global/claude-hooks.instructions.md
+++ b/ai/global/claude-hooks.instructions.md
@@ -16,8 +16,8 @@ A `PreToolUse` hook denial (a tool result explaining the call was blocked) means
 
 - Fix the specific thing the denial names and retry **immediately, in the same turn**.
 - Never end a turn saying you are "waiting for it to finish" or "waiting for a completion
-  notification" for a denied command. This matters most acutely in a single-shot session — there
-  is no later turn for that notification to land in, so uncommitted work is silently abandoned —
+  notification" for a denied command. This matters most acutely in a single-shot session: there
+  is no later turn for that notification to land in, so uncommitted work is silently abandoned,
   but the same misread is just as wrong in an interactive session with turns to spare.
 
 ## Read the Denial's Stated Reason Literally (MANDATORY)

--- a/ai/global/claude-hooks.instructions.md
+++ b/ai/global/claude-hooks.instructions.md
@@ -16,7 +16,6 @@ commands must use "git -C <dir>" format`) means the command **never started**. T
 flight and nothing will ever notify you about it later.
 
 - Fix the specific thing the denial names and retry **immediately, in the same turn**.
-- A denial is not "started, now wait for it"; it is "never started, try again correctly."
 - Never end a turn — including a single-shot orchestrator-driven session — saying you are
   "waiting for it to finish" or "waiting for a completion notification" for a command that was
   denied. A single-shot session gets no later turn for that notification to land in, so any
@@ -80,9 +79,8 @@ a bug.
 
 ## Background
 
-Drawn from live evidence gathered while fixing `credfeto/credfeto-orchestrator#1281` ("Agent
-misreads a hook-blocked backgrounded `git commit` as in-flight, waits for an unreachable
-notification, and silently loses its work") and `#1282`. That fix added the same denial-handling
-guidance to `credfeto-orchestrator`'s own container-prompt generator, which only reaches
-orchestrator-driven, single-shot container sessions. This file makes the same knowledge available
-to every session type that loads this template's global instructions, interactive included.
+Drawn from live evidence gathered while fixing `credfeto/credfeto-orchestrator#1281` and `#1282`
+(the failure mode is described above). That fix added the same denial-handling guidance to
+`credfeto-orchestrator`'s own container-prompt generator, which only reaches orchestrator-driven,
+single-shot container sessions. This file makes the same knowledge available to every session type
+that loads this template's global instructions, interactive included.

--- a/ai/global/claude-hooks.instructions.md
+++ b/ai/global/claude-hooks.instructions.md
@@ -16,18 +16,14 @@ commands must use "git -C <dir>" format`) means the command **never started**. T
 flight and nothing will ever notify you about it later.
 
 - Fix the specific thing the denial names and retry **immediately, in the same turn**.
-- Never end a turn — including a single-shot orchestrator-driven session — saying you are
-  "waiting for it to finish" or "waiting for a completion notification" for a command that was
-  denied. A single-shot session gets no later turn for that notification to land in, so any
-  uncommitted work is silently abandoned the moment you stop.
-- This matters most acutely in a single-shot session, but the underlying misread is exactly as
-  wrong in an interactive session that has turns to spare; do not let extra turns excuse
-  re-checking a denied call as if it might still complete on its own.
+- Never end a turn saying you are "waiting for it to finish" or "waiting for a completion
+  notification" for a denied command. This matters most acutely in a single-shot session — there
+  is no later turn for that notification to land in, so uncommitted work is silently abandoned —
+  but the same misread is just as wrong in an interactive session with turns to spare.
 
 ## Read the Denial's Stated Reason Literally (MANDATORY)
 
-Each hook names exactly what is wrong; fix that specific thing rather than guessing at a different
-cause:
+What "the specific thing" above means in practice:
 
 - `git commands must use "git -C <dir>" format` means add `-C <dir>` to that git invocation, not a
   general git problem.
@@ -53,7 +49,7 @@ agents doing; instead, satisfy both rules in the one call that is retried:
 git -C <dir> commit -m "..."
 ```
 
-invoked with `run_in_background: true` set on that same tool call, not as a second attempt.
+invoked with `run_in_background: true` set on that same tool call.
 
 ## Reference: Installed Hook Set
 
@@ -66,7 +62,7 @@ this file was written:
 | `command-allowlist` (data file, not a hook) | N/A | Known-good command names for `reject-obfuscated-commands`; a command not on this list (and not on `command-blocklist`, which wins) is rejected outright. |
 | `command-blocklist` (data file, not a hook) | N/A | Known-bad command names for `reject-obfuscated-commands` (e.g. `eval`, `source`, `bash`) that are rejected even though they are plain bare words, because each one hides or re-enters execution in a way this check cannot see through. |
 | `env-var-blocklist` (data file, not a hook) | N/A | Environment variables (`PATH`, `IFS`, `LD_PRELOAD`, `GIT_*`, and similar) that `reject-obfuscated-commands` refuses to let a command assign, because they change how *other* commands are located, parsed, or attributed. |
-| `enforce-git-dash-c` | Any git subcommand not written as `git -C <dir> <command>` | Keeps every git call explicit about which repository it targets and avoids leaving the shell's working directory changed by a stray `cd`; see [Running Git Commands in a Specific Directory](git.instructions.md#running-git-commands-in-a-specific-directory). |
+| `enforce-git-dash-c` | Any git subcommand not written as `git -C <dir> <command>` | See [Running Git Commands in a Specific Directory](git.instructions.md#running-git-commands-in-a-specific-directory). |
 | `enforce-git-identity` | Git subcommands that create or rewrite commits (or precede one, like `fetch`) unless git identity and GPG signing are correctly configured | Prevents an unsigned or misattributed commit from being created at all, rather than relying on review to catch it afterwards. |
 | `enforce-background-for-long-running-commands` | `git commit`, `pre-commit` (direct invocation), `dotnet build`, `dotnet test`, `npm test`, and `bun test` unless the call sets `run_in_background: true` | See [Never Truncate Test/Commit Commands](task-workflow.instructions.md#never-truncate-testcommit-commands-mandatory) for why these five have no safe foreground timeout. |
 | `block-git-worktree` | `git worktree add` | Worktrees split repo state across multiple linked checkouts sharing one object store; this template's tooling assumes a single checkout per repo directory, and an errant `worktree add` has previously left the primary checkout bare with no work tree of its own. See [Avoid `git worktree`](git.instructions.md#avoid-git-worktree). |
@@ -76,11 +72,3 @@ If a command is blocked by a hook not listed here, or this table no longer match
 `$HOME/.claude/hooks` on a given container, treat the table as stale rather than the denial as
 wrong: read the hook's own header comment (each one documents its rationale) before assuming it is
 a bug.
-
-## Background
-
-Drawn from live evidence gathered while fixing `credfeto/credfeto-orchestrator#1281` and `#1282`
-(the failure mode is described above). That fix added the same denial-handling guidance to
-`credfeto-orchestrator`'s own container-prompt generator, which only reaches orchestrator-driven,
-single-shot container sessions. This file makes the same knowledge available to every session type
-that loads this template's global instructions, interactive included.

--- a/ai/global/claude-hooks.instructions.md
+++ b/ai/global/claude-hooks.instructions.md
@@ -1,0 +1,88 @@
+# Claude Code Hook Interaction Instructions
+
+[Back to Global Instructions Index](index.md)
+
+This template's development containers (and any interactive session with the hooks installed via
+`install-claude-hooks`) run a fixed set of Claude Code `PreToolUse` hooks against every Bash tool
+call. This file covers how to interpret a hook **denial** correctly; for how to background and
+poll long-running commands once a call has actually been accepted, see
+[Background Tasks and Monitor Tool](task-workflow.instructions.md#background-tasks-and-monitor-tool-mandatory)
+and [Never Truncate Test/Commit Commands](task-workflow.instructions.md#never-truncate-testcommit-commands-mandatory).
+
+## A Denial Means the Command Never Ran (MANDATORY)
+
+A `PreToolUse` hook denial (a tool result explaining the call was blocked, e.g. `Blocked: git
+commands must use "git -C <dir>" format`) means the command **never started**. There is nothing in
+flight and nothing will ever notify you about it later.
+
+- Fix the specific thing the denial names and retry **immediately, in the same turn**.
+- A denial is not "started, now wait for it"; it is "never started, try again correctly."
+- Never end a turn, or in a single-shot orchestrator-driven session, a session, saying you are
+  "waiting for it to finish" or "waiting for a completion notification" for a command that was
+  denied. A single-shot session gets no later turn for that notification to land in, so any
+  uncommitted work is silently abandoned the moment you stop.
+- This matters most acutely in a single-shot session, but the underlying misread is exactly as
+  wrong in an interactive session that has turns to spare; do not let extra turns excuse
+  re-checking a denied call as if it might still complete on its own.
+
+## Read the Denial's Stated Reason Literally (MANDATORY)
+
+Each hook names exactly what is wrong; fix that specific thing rather than guessing at a different
+cause:
+
+- `git commands must use "git -C <dir>" format` means add `-C <dir>` to that git invocation, not a
+  general git problem.
+- `git commit must run with run_in_background: true` means add that tool parameter, not switch to
+  a different commit approach.
+
+## Prefer the Tool's Own Backgrounding Parameter (MANDATORY)
+
+Use the tool's own `run_in_background: true` parameter, never shell-level backgrounding (`&`,
+`nohup ... &`, `disown`). Shell-level backgrounding is blocked outright by
+`enforce-background-for-long-running-commands` (see below) and has caused the exact
+denial-misread-as-in-flight failure described above in live incidents
+(`credfeto/credfeto-orchestrator#1281`).
+
+## Combined Example: Satisfying Two Hooks at Once
+
+The most common interaction is a command that must satisfy both a git-invocation-shape hook and a
+must-be-backgrounded hook in the same call. Satisfying each hook's rule individually by trial and
+error (fix one, get denied by the other, fix that, and so on) is what several live incidents show
+agents doing; instead, satisfy both rules in the one call that is retried:
+
+```text
+git -C <dir> commit -m "..."
+```
+
+invoked with `run_in_background: true` set on that same tool call, not as a second attempt.
+
+## Reference: Installed Hook Set
+
+The exact hook set installed at `$HOME/.claude/hooks` (from `install-claude-hooks`) at the time
+this file was written:
+
+| Hook | Blocks | Why |
+| --- | --- | --- |
+| `reject-obfuscated-commands` | Any Bash command not built from plain, obviously-spelled command words (indirect execution, sub-shells, wrapper-flag smuggling) | Text/regex scanning for banned patterns is an arms race that never converges (eight bypass rounds found in the prior hand-rolled approach: `credfeto/cs-template#1159`/`#1105`); this hook parses with a real shell parser and applies policy to the resulting AST instead. Reads `command-allowlist`, `command-blocklist`, and `env-var-blocklist` as its data tables. |
+| `command-allowlist` (data file, not a hook) | N/A | Known-good command names for `reject-obfuscated-commands`; a command not on this list (and not on `command-blocklist`, which wins) is rejected outright. |
+| `command-blocklist` (data file, not a hook) | N/A | Known-bad command names for `reject-obfuscated-commands` (e.g. `eval`, `source`, `bash`) that are rejected even though they are plain bare words, because each one hides or re-enters execution in a way this check cannot see through. |
+| `env-var-blocklist` (data file, not a hook) | N/A | Environment variables (`PATH`, `IFS`, `LD_PRELOAD`, `GIT_*`, and similar) that `reject-obfuscated-commands` refuses to let a command assign, because they change how *other* commands are located, parsed, or attributed. |
+| `enforce-git-dash-c` | Any git subcommand not written as `git -C <dir> <command>` | Keeps every git call explicit about which repository it targets and avoids leaving the shell's working directory changed by a stray `cd`; see [Running Git Commands in a Specific Directory](git.instructions.md#running-git-commands-in-a-specific-directory). |
+| `enforce-git-identity` | Git subcommands that create or rewrite commits (or precede one, like `fetch`) unless git identity and GPG signing are correctly configured | Prevents an unsigned or misattributed commit from being created at all, rather than relying on review to catch it afterwards. |
+| `enforce-background-for-long-running-commands` | `git commit`, `pre-commit` (direct invocation), `dotnet build`, `dotnet test`, `npm test`, and `bun test` unless the call sets `run_in_background: true` | These five commands have no bounded, predictable duration; a foreground run that outlives the tool's own timeout gets killed mid-run, skipping the target process's own cleanup and leaving orphaned state behind. See [Never Truncate Test/Commit Commands](task-workflow.instructions.md#never-truncate-testcommit-commands-mandatory). |
+| `block-git-worktree` | `git worktree add` | Worktrees split repo state across multiple linked checkouts sharing one object store; this template's tooling assumes a single checkout per repo directory, and an errant `worktree add` has previously left the primary checkout bare with no work tree of its own. See [Avoid `git worktree`](git.instructions.md#avoid-git-worktree). |
+| `block-dotnet-tool-install` | `dotnet tool install` (local or global) and `dotnet new tool-manifest` | This container's .NET global tools are pinned and baked into the image at build time; installing an unpinned tool at runtime would bypass the dependency-selection review the pinned set went through. |
+
+If a command is blocked by a hook not listed here, or this table no longer matches
+`$HOME/.claude/hooks` on a given container, treat the table as stale rather than the denial as
+wrong: read the hook's own header comment (each one documents its rationale) before assuming it is
+a bug.
+
+## Background
+
+Drawn from live evidence gathered while fixing `credfeto/credfeto-orchestrator#1281` ("Agent
+misreads a hook-blocked backgrounded `git commit` as in-flight, waits for an unreachable
+notification, and silently loses its work") and `#1282`. That fix added the same denial-handling
+guidance to `credfeto-orchestrator`'s own container-prompt generator, which only reaches
+orchestrator-driven, single-shot container sessions. This file makes the same knowledge available
+to every session type that loads this template's global instructions, interactive included.

--- a/ai/global/claude-hooks.instructions.md
+++ b/ai/global/claude-hooks.instructions.md
@@ -17,7 +17,7 @@ flight and nothing will ever notify you about it later.
 
 - Fix the specific thing the denial names and retry **immediately, in the same turn**.
 - A denial is not "started, now wait for it"; it is "never started, try again correctly."
-- Never end a turn, or in a single-shot orchestrator-driven session, a session, saying you are
+- Never end a turn — including a single-shot orchestrator-driven session — saying you are
   "waiting for it to finish" or "waiting for a completion notification" for a command that was
   denied. A single-shot session gets no later turn for that notification to land in, so any
   uncommitted work is silently abandoned the moment you stop.
@@ -69,7 +69,7 @@ this file was written:
 | `env-var-blocklist` (data file, not a hook) | N/A | Environment variables (`PATH`, `IFS`, `LD_PRELOAD`, `GIT_*`, and similar) that `reject-obfuscated-commands` refuses to let a command assign, because they change how *other* commands are located, parsed, or attributed. |
 | `enforce-git-dash-c` | Any git subcommand not written as `git -C <dir> <command>` | Keeps every git call explicit about which repository it targets and avoids leaving the shell's working directory changed by a stray `cd`; see [Running Git Commands in a Specific Directory](git.instructions.md#running-git-commands-in-a-specific-directory). |
 | `enforce-git-identity` | Git subcommands that create or rewrite commits (or precede one, like `fetch`) unless git identity and GPG signing are correctly configured | Prevents an unsigned or misattributed commit from being created at all, rather than relying on review to catch it afterwards. |
-| `enforce-background-for-long-running-commands` | `git commit`, `pre-commit` (direct invocation), `dotnet build`, `dotnet test`, `npm test`, and `bun test` unless the call sets `run_in_background: true` | These five commands have no bounded, predictable duration; a foreground run that outlives the tool's own timeout gets killed mid-run, skipping the target process's own cleanup and leaving orphaned state behind. See [Never Truncate Test/Commit Commands](task-workflow.instructions.md#never-truncate-testcommit-commands-mandatory). |
+| `enforce-background-for-long-running-commands` | `git commit`, `pre-commit` (direct invocation), `dotnet build`, `dotnet test`, `npm test`, and `bun test` unless the call sets `run_in_background: true` | See [Never Truncate Test/Commit Commands](task-workflow.instructions.md#never-truncate-testcommit-commands-mandatory) for why these five have no safe foreground timeout. |
 | `block-git-worktree` | `git worktree add` | Worktrees split repo state across multiple linked checkouts sharing one object store; this template's tooling assumes a single checkout per repo directory, and an errant `worktree add` has previously left the primary checkout bare with no work tree of its own. See [Avoid `git worktree`](git.instructions.md#avoid-git-worktree). |
 | `block-dotnet-tool-install` | `dotnet tool install` (local or global) and `dotnet new tool-manifest` | This container's .NET global tools are pinned and baked into the image at build time; installing an unpinned tool at runtime would bypass the dependency-selection review the pinned set went through. |
 

--- a/ai/global/claude-hooks.instructions.md
+++ b/ai/global/claude-hooks.instructions.md
@@ -11,9 +11,8 @@ and [Never Truncate Test/Commit Commands](task-workflow.instructions.md#never-tr
 
 ## A Denial Means the Command Never Ran (MANDATORY)
 
-A `PreToolUse` hook denial (a tool result explaining the call was blocked, e.g. `Blocked: git
-commands must use "git -C <dir>" format`) means the command **never started**. There is nothing in
-flight and nothing will ever notify you about it later.
+A `PreToolUse` hook denial (a tool result explaining the call was blocked) means the command
+**never started**. There is nothing in flight and nothing will ever notify you about it later.
 
 - Fix the specific thing the denial names and retry **immediately, in the same turn**.
 - Never end a turn saying you are "waiting for it to finish" or "waiting for a completion
@@ -38,12 +37,12 @@ Use the tool's own `run_in_background: true` parameter, never shell-level backgr
 denial-misread-as-in-flight failure described above in live incidents
 (`credfeto/credfeto-orchestrator#1281`).
 
-## Combined Example: Satisfying Two Hooks at Once
+## Satisfy Every Applicable Hook in the Same Retry
 
-The most common interaction is a command that must satisfy both a git-invocation-shape hook and a
-must-be-backgrounded hook in the same call. Satisfying each hook's rule individually by trial and
-error (fix one, get denied by the other, fix that, and so on) is what several live incidents show
-agents doing; instead, satisfy both rules in the one call that is retried:
+Satisfying each hook's rule individually by trial and error (fix one, get denied by the other, fix
+that, and so on) is what several live incidents show agents doing; instead, satisfy every
+applicable rule in the one call that is retried. The most common case is a command that must
+satisfy both a git-invocation-shape hook and a must-be-backgrounded hook at once:
 
 ```text
 git -C <dir> commit -m "..."

--- a/ai/global/index.md
+++ b/ai/global/index.md
@@ -15,6 +15,7 @@ Read all of these before starting any task, regardless of language or context.
 | File | Covers |
 | --- | --- |
 | [git.instructions.md](git.instructions.md) | Prerequisites, build/test verification, git identity/GPG, branching, commits, GitHub issues, template rule escalation |
+| [claude-hooks.instructions.md](claude-hooks.instructions.md) | Claude Code `PreToolUse` hook denials: a denial means the command never ran, read its stated reason literally and retry immediately, reference index of the installed hook set |
 | [git-rebasing.instructions.md](git-rebasing.instructions.md) | When to rebase (fetch/check/rebase), version-conflict resolution when merging or rebasing |
 | [task-workflow.instructions.md](task-workflow.instructions.md) | Agent routing table, model selection, failure handling, issue/PR assignment, Workflow project board, commit cadence, resuming work, command timeouts, ad-hoc prompt intake, prompt traceability |
 | [code-quality.instructions.md](code-quality.instructions.md) | Code coverage, tests, async, immutability, parameterised tests, refactoring |

--- a/ai/global/task-workflow.instructions.md
+++ b/ai/global/task-workflow.instructions.md
@@ -193,6 +193,10 @@ For complex files, commit+push+update after each round; do not wait until fully 
 
 ## Background Tasks and Monitor Tool (MANDATORY)
 
+This section covers polling a command that was **accepted** and is running; if a command was
+instead **denied** by a `PreToolUse` hook, it never started at all and there is nothing to poll
+for, see [claude-hooks.instructions.md](claude-hooks.instructions.md) for that case.
+
 When using the Monitor tool to watch a background Bash task, the poll condition in the `until` loop **must** be provably satisfiable; a condition that can never be met loops forever and blocks the entire session.
 
 ### Rules for poll conditions
@@ -241,7 +245,7 @@ When using the Monitor tool to watch a background Bash task, the poll condition 
 
 ## Never Truncate Test/Commit Commands (MANDATORY)
 
-This is a distinct concern from the poll-loop timeouts above: those govern how long you wait for something _else_ to finish; this governs the timeout on the command _actually doing the work_.
+This is a distinct concern from the poll-loop timeouts above: those govern how long you wait for something _else_ to finish; this governs the timeout on the command _actually doing the work_. It also assumes the command was accepted; a call rejected outright by `enforce-background-for-long-running-commands` for missing `run_in_background: true` never ran, see [claude-hooks.instructions.md](claude-hooks.instructions.md).
 
 `git commit`/`pre-commit`, `dotnet build`, `dotnet test`, `npm test`, and `bun test` have no bounded, predictable duration: `pre-commit` can run a heavy hook chain (`dotnet buildcheck` across every project, `trivy`, `hadolint`), `dotnet build` runs through a large analyzer stack (Roslynator, SonarAnalyzer, Meziantou, Threading, Security Code Scan, and more) plus NuGet restore, and test runs scale with what changed. A commit has already been killed mid-run on a foreground timeout in a live session. There is no timeout value that is both practical and safe to pick for any of these five commands, so do not try to pick one.
 

--- a/ai/global/task-workflow.instructions.md
+++ b/ai/global/task-workflow.instructions.md
@@ -245,7 +245,7 @@ When using the Monitor tool to watch a background Bash task, the poll condition 
 
 ## Never Truncate Test/Commit Commands (MANDATORY)
 
-This is a distinct concern from the poll-loop timeouts above: those govern how long you wait for something _else_ to finish; this governs the timeout on the command _actually doing the work_ (a call rejected outright for missing `run_in_background: true` never ran — see [claude-hooks.instructions.md](claude-hooks.instructions.md) for that case, not here).
+This is a distinct concern from the poll-loop timeouts above: those govern how long you wait for something _else_ to finish; this governs the timeout on the command _actually doing the work_ (a call rejected outright for missing `run_in_background: true` never ran; see [claude-hooks.instructions.md](claude-hooks.instructions.md) for that case, not here).
 
 `git commit`/`pre-commit`, `dotnet build`, `dotnet test`, `npm test`, and `bun test` have no bounded, predictable duration: `pre-commit` can run a heavy hook chain (`dotnet buildcheck` across every project, `trivy`, `hadolint`), `dotnet build` runs through a large analyzer stack (Roslynator, SonarAnalyzer, Meziantou, Threading, Security Code Scan, and more) plus NuGet restore, and test runs scale with what changed. A commit has already been killed mid-run on a foreground timeout in a live session. There is no timeout value that is both practical and safe to pick for any of these five commands, so do not try to pick one.
 

--- a/ai/global/task-workflow.instructions.md
+++ b/ai/global/task-workflow.instructions.md
@@ -245,7 +245,7 @@ When using the Monitor tool to watch a background Bash task, the poll condition 
 
 ## Never Truncate Test/Commit Commands (MANDATORY)
 
-This is a distinct concern from the poll-loop timeouts above: those govern how long you wait for something _else_ to finish; this governs the timeout on the command _actually doing the work_. It also assumes the command was accepted; a call rejected outright by `enforce-background-for-long-running-commands` for missing `run_in_background: true` never ran, see [claude-hooks.instructions.md](claude-hooks.instructions.md).
+This is a distinct concern from the poll-loop timeouts above: those govern how long you wait for something _else_ to finish; this governs the timeout on the command _actually doing the work_ (a call rejected outright for missing `run_in_background: true` never ran — see [claude-hooks.instructions.md](claude-hooks.instructions.md) for that case, not here).
 
 `git commit`/`pre-commit`, `dotnet build`, `dotnet test`, `npm test`, and `bun test` have no bounded, predictable duration: `pre-commit` can run a heavy hook chain (`dotnet buildcheck` across every project, `trivy`, `hadolint`), `dotnet build` runs through a large analyzer stack (Roslynator, SonarAnalyzer, Meziantou, Threading, Security Code Scan, and more) plus NuGet restore, and test runs scale with what changed. A commit has already been killed mid-run on a foreground timeout in a live session. There is no timeout value that is both practical and safe to pick for any of these five commands, so do not try to pick one.
 


### PR DESCRIPTION
## Summary

Adds a new always-loaded global instructions file, `ai/global/claude-hooks.instructions.md`,
documenting how to interpret a Claude Code `PreToolUse` hook denial: the command never ran at
all, so the denial's stated reason should be read literally and the call retried immediately in
the same turn, rather than waiting for a notification that will never arrive. Includes a combined
`git -C <dir> ...` + `run_in_background: true` example and a reference table of the hook set
actually installed under `$HOME/.claude/hooks` (verified live in this session, not guessed).

- `ai/global/claude-hooks.instructions.md` (new)
- `ai/global/index.md` - added to the Always Load table
- `ai/global/task-workflow.instructions.md` - cross-referenced from the Background Tasks/Monitor
  Tool and Never Truncate Test/Commit Commands sections

No `CHANGELOG.md` entry: `credfeto/cs-template` is named explicitly by the skip rule in
`changelog.instructions.md` ("kept blank for template consumers"), and `pr-lint.yml`'s
changelog-check jobs already exclude `-template` repositories, so this is expected, not an
oversight.

Closes #1024

## Test plan

- [x] Documentation-only change; validated by inspection (index row reads clearly, new file
      follows existing instructions-file conventions, cross-references do not duplicate existing
      polling/timeout content).
- [x] Baseline and commit-time `pre-commit --all-files` runs both passed cleanly.