### PR TITLE
docs: recommend Glob over find for simple in-workspace file listing

### DIFF
--- a/ai/global/index.md
+++ b/ai/global/index.md
@@ -16,6 +16,7 @@ Read all of these before starting any task, regardless of language or context.
 | --- | --- |
 | [git.instructions.md](git.instructions.md) | Prerequisites, build/test verification, git identity/GPG, branching, commits, GitHub issues, template rule escalation |
 | [claude-hooks.instructions.md](claude-hooks.instructions.md) | Claude Code `PreToolUse` hook denials: a denial means the command never ran, read its stated reason literally and retry immediately, reference index of the installed hook set |
+| [tool-preferences.instructions.md](tool-preferences.instructions.md) | Which tool to reach for when more than one could do the job: `Glob` over `find` for simple file listing |
 | [git-rebasing.instructions.md](git-rebasing.instructions.md) | When to rebase (fetch/check/rebase), version-conflict resolution when merging or rebasing |
 | [task-workflow.instructions.md](task-workflow.instructions.md) | Agent routing table, model selection, failure handling, issue/PR assignment, Workflow project board, commit cadence, resuming work, command timeouts, ad-hoc prompt intake, prompt traceability |
 | [code-quality.instructions.md](code-quality.instructions.md) | Code coverage, tests, async, immutability, parameterised tests, refactoring |

--- a/ai/global/tool-preferences.instructions.md
+++ b/ai/global/tool-preferences.instructions.md
@@ -1,0 +1,16 @@
+# Tool Preference Instructions
+
+[Back to Global Instructions Index](index.md)
+
+This file covers which tool to reach for when more than one could technically do the job - a
+built-in Claude Code tool over an equivalent Bash command, or one Bash command over another. This
+is distinct from [claude-hooks.instructions.md](claude-hooks.instructions.md), which covers how to
+interpret a hook *denial* once a tool call has already been made; the rules here are about the
+choice made before that call happens.
+
+## Prefer Glob Over find for Simple File Listing (MANDATORY)
+
+Use the `Glob` tool, not `find`, to list files matching a name/path pattern inside the workspace - it
+is read-only by construction, always available, and does not go through the Bash-command hook chain
+at all. Reach for `find` only when the need is something `Glob` cannot express: ownership/permission
+predicates (`-user`, `-group`, `-perm`), time predicates (`-mtime`, `-newer`), or `-exec`.


### PR DESCRIPTION
Closes #1032.

Adds a new `ai/global/tool-preferences.instructions.md`, listed in the "Always Load" index, covering which tool to reach for when more than one could do the job. This is distinct from `claude-hooks.instructions.md`, which covers interpreting a hook *denial* after a tool call has already been made - `tool-preferences.instructions.md` covers the choice made before that call happens, and is the right home for further entries of this kind going forward.

## Why

`find` shows up often in live `--permission-mode dontAsk` denial telemetry collected in `credfeto/credfeto-orchestrator#1342`/`#1343`, but `find` itself is essentially never the actual root cause - the real cause is almost always searching outside the trusted workspace dir, piping into a blocklisted command, or an unrelated compound-command issue. `Glob` is a first-class Claude Code tool (not a `Bash` subprocess), already allowlisted, read-only by nature, and has never been observed denied.

Not proposing blocking or auto-rewriting `find`: a `PreToolUse` hook's `updatedInput` rewrite can't redirect execution to a different tool (different input shape), and `find` usage needing ownership/permission/time predicates or `-exec` has no `Glob` equivalent.

Downstream tracker: credfeto/credfeto-orchestrator#1352 (will close once this merges and the next vendor sync pulls it in).

## How Has This Been Tested

- [x] All unit tests pass. (N/A - docs only)
- [x] Manual Testing: reviewed rendered markdown for formatting.

## Types of changes

- [x] Docs change

## Checklist

- [x] I have added tests to cover my changes. (N/A - docs only)
- [x] Unreleased section of CHANGELOG.md has been updated with details of this PR. (N/A - `ai/global/*` instruction file change, per changelog skip rule)
- [x] No user-controlled or step-output value is string-interpolated directly into a `run:`/`script:` body. (N/A - no workflow changes)