### PR TITLE
docs(ai): check for an existing branch before creating one for an issue

### DIFF
--- a/ai/global/agent-roles.instructions.md
+++ b/ai/global/agent-roles.instructions.md
@@ -27,8 +27,8 @@ When picking up an **Issue** that has no existing PR:
 
    - `false` → Plan mode (steps 2–3 below).
    - `true` → Plan exists. How approval is signalled depends on whether a Workflow board is configured (the orchestrator passes this context in your CLAUDE.md):
-     - **Board configured**: check whether a human has set the board status to **Approved**. If yes → skip to implementation, checking for an existing branch first ([git.instructions.md#branching](git.instructions.md#branching) - a previous session may have pushed work and died before opening a PR). If not yet → revise or re-post the plan, mark Blocked, STOP (step 2).
-     - **No board**: check for a human approval comment posted **after** the plan comment (keywords: `approved` / `go ahead` / `looks good` / `lgtm`, case-insensitive, whole word). If found → skip to implementation, checking for an existing branch first ([git.instructions.md#branching](git.instructions.md#branching) - a previous session may have pushed work and died before opening a PR). If not → revise or re-post, mark Blocked, STOP (step 2).
+     - **Board configured**: check whether a human has set the board status to **Approved**. If yes → skip to implementation, checking for an existing branch first (see [git.instructions.md#branching](git.instructions.md#branching)). If not yet → revise or re-post the plan, mark Blocked, STOP (step 2).
+     - **No board**: check for a human approval comment posted **after** the plan comment (keywords: `approved` / `go ahead` / `looks good` / `lgtm`, case-insensitive, whole word). If found → skip to implementation, checking for an existing branch first (see [git.instructions.md#branching](git.instructions.md#branching)). If not → revise or re-post, mark Blocked, STOP (step 2).
 
 2. **Plan mode**: produce a concrete implementation plan using `/plan`, then post it as an issue comment in **exactly** this format:
 

--- a/ai/global/agent-roles.instructions.md
+++ b/ai/global/agent-roles.instructions.md
@@ -27,8 +27,10 @@ When picking up an **Issue** that has no existing PR:
 
    - `false` → Plan mode (steps 2–3 below).
    - `true` → Plan exists. How approval is signalled depends on whether a Workflow board is configured (the orchestrator passes this context in your CLAUDE.md):
-     - **Board configured**: check whether a human has set the board status to **Approved**. If yes → skip to implementation, checking for an existing branch first (see [git.instructions.md#branching](git.instructions.md#branching)). If not yet → revise or re-post the plan, mark Blocked, STOP (step 2).
-     - **No board**: check for a human approval comment posted **after** the plan comment (keywords: `approved` / `go ahead` / `looks good` / `lgtm`, case-insensitive, whole word). If found → skip to implementation, checking for an existing branch first (see [git.instructions.md#branching](git.instructions.md#branching)). If not → revise or re-post, mark Blocked, STOP (step 2).
+     - **Board configured**: check whether a human has set the board status to **Approved**. If yes → skip to implementation. If not yet → revise or re-post the plan, mark Blocked, STOP (step 2).
+     - **No board**: check for a human approval comment posted **after** the plan comment (keywords: `approved` / `go ahead` / `looks good` / `lgtm`, case-insensitive, whole word). If found → skip to implementation. If not → revise or re-post, mark Blocked, STOP (step 2).
+
+   Either way, before skipping to implementation: check for an existing branch first (see [git.instructions.md#branching](git.instructions.md#branching)) — a previous session may have pushed work and died before opening a PR.
 
 2. **Plan mode**: produce a concrete implementation plan using `/plan`, then post it as an issue comment in **exactly** this format:
 

--- a/ai/global/agent-roles.instructions.md
+++ b/ai/global/agent-roles.instructions.md
@@ -27,8 +27,8 @@ When picking up an **Issue** that has no existing PR:
 
    - `false` → Plan mode (steps 2–3 below).
    - `true` → Plan exists. How approval is signalled depends on whether a Workflow board is configured (the orchestrator passes this context in your CLAUDE.md):
-     - **Board configured**: check whether a human has set the board status to **Approved**. If yes → skip to implementation. If not yet → revise or re-post the plan, mark Blocked, STOP (step 2).
-     - **No board**: check for a human approval comment posted **after** the plan comment (keywords: `approved` / `go ahead` / `looks good` / `lgtm`, case-insensitive, whole word). If found → skip to implementation. If not → revise or re-post, mark Blocked, STOP (step 2).
+     - **Board configured**: check whether a human has set the board status to **Approved**. If yes → skip to implementation, checking for an existing branch first ([git.instructions.md#branching](git.instructions.md#branching) - a previous session may have pushed work and died before opening a PR). If not yet → revise or re-post the plan, mark Blocked, STOP (step 2).
+     - **No board**: check for a human approval comment posted **after** the plan comment (keywords: `approved` / `go ahead` / `looks good` / `lgtm`, case-insensitive, whole word). If found → skip to implementation, checking for an existing branch first ([git.instructions.md#branching](git.instructions.md#branching) - a previous session may have pushed work and died before opening a PR). If not → revise or re-post, mark Blocked, STOP (step 2).
 
 2. **Plan mode**: produce a concrete implementation plan using `/plan`, then post it as an issue comment in **exactly** this format:
 

--- a/ai/global/agent-roles.instructions.md
+++ b/ai/global/agent-roles.instructions.md
@@ -30,7 +30,7 @@ When picking up an **Issue** that has no existing PR:
      - **Board configured**: check whether a human has set the board status to **Approved**. If yes → skip to implementation. If not yet → revise or re-post the plan, mark Blocked, STOP (step 2).
      - **No board**: check for a human approval comment posted **after** the plan comment (keywords: `approved` / `go ahead` / `looks good` / `lgtm`, case-insensitive, whole word). If found → skip to implementation. If not → revise or re-post, mark Blocked, STOP (step 2).
 
-   Either way, before skipping to implementation: check for an existing branch first (see [git.instructions.md#branching](git.instructions.md#branching)) — a previous session may have pushed work and died before opening a PR.
+   Either way, before skipping to implementation, check for an existing branch first (see [git.instructions.md#branching](git.instructions.md#branching)).
 
 2. **Plan mode**: produce a concrete implementation plan using `/plan`, then post it as an issue comment in **exactly** this format:
 

--- a/ai/global/git.instructions.md
+++ b/ai/global/git.instructions.md
@@ -110,11 +110,11 @@ Before any command that can discard uncommitted work (`git reset --hard`, `git c
 - Ensure `main` is up-to-date with `origin` before starting.
 - Continue in the same branch until the task changes.
 - Before continuing work on an existing branch, check if `origin/main` has advanced; if so, rebase first. This is done as part of the [Pre-Work Baseline Check](#pre-work-baseline-check-mandatory-before-starting-any-work) above, before the baseline hook runs; see [git-rebasing.instructions.md](git-rebasing.instructions.md) for the rebase procedure and version-conflict resolution.
-- **Before creating a new branch for an issue, check whether one already exists for it**: a previous session may have pushed work and then been interrupted before ever opening a PR.
+- **Before creating a new branch for an issue, check whether one already exists for it**: a previous session may have pushed work and then been interrupted before ever opening a PR. This is the branch-only counterpart to the PR check in [task-workflow.instructions.md's "Bot-Created PRs" section](task-workflow.instructions.md#bot-created-prs-mandatory-treat-as-your-own) ("Checking for existing work before branching"), which only catches work that already has a PR open.
 
   ```bash
   gh api "repos/<owner>/<repo>/branches" --paginate --jq '.[].name' \
-    | grep -E "^[A-Za-z]+/<issue-number>([^0-9]|$)"
+    | grep -E "^[A-Za-z]+/<issue-number>\b"
   ```
 
   - No match: branch fresh from `main` as normal.

--- a/ai/global/git.instructions.md
+++ b/ai/global/git.instructions.md
@@ -110,6 +110,16 @@ Before any command that can discard uncommitted work (`git reset --hard`, `git c
 - Ensure `main` is up-to-date with `origin` before starting.
 - Continue in the same branch until the task changes.
 - Before continuing work on an existing branch, check if `origin/main` has advanced; if so, rebase first. This is done as part of the [Pre-Work Baseline Check](#pre-work-baseline-check-mandatory-before-starting-any-work) above, before the baseline hook runs; see [git-rebasing.instructions.md](git-rebasing.instructions.md) for the rebase procedure and version-conflict resolution.
+- **Before creating a new branch for an issue, check whether one already exists for it**: a previous session may have pushed work and then been interrupted before ever opening a PR.
+
+  ```bash
+  gh api "repos/<owner>/<repo>/branches" --paginate --jq '.[].name' \
+    | grep -E "^[A-Za-z]+/<issue-number>([^0-9]|$)"
+  ```
+
+  - No match: branch fresh from `main` as normal.
+  - Match found, not ahead of `main`: treat the same as no match; branch fresh from `main`.
+  - Match found and ahead of `main`: check it out and continue from there instead of branching again; rebase onto `origin/main` first if it has advanced (see [Pre-Work Baseline Check](#pre-work-baseline-check-mandatory-before-starting-any-work) above). Do not open a second branch/PR for the same issue.
 
 ## Pushing Branches
 

--- a/ai/global/git.instructions.md
+++ b/ai/global/git.instructions.md
@@ -110,14 +110,22 @@ Before any command that can discard uncommitted work (`git reset --hard`, `git c
 - Ensure `main` is up-to-date with `origin` before starting.
 - Continue in the same branch until the task changes.
 - Before continuing work on an existing branch, check if `origin/main` has advanced; if so, rebase first. This is done as part of the [Pre-Work Baseline Check](#pre-work-baseline-check-mandatory-before-starting-any-work) above, before the baseline hook runs; see [git-rebasing.instructions.md](git-rebasing.instructions.md) for the rebase procedure and version-conflict resolution.
-- **Before creating a new branch for an issue, check whether one already exists for it**: a previous session may have pushed work and then been interrupted before ever opening a PR. This is the branch-only counterpart to the PR check in [task-workflow.instructions.md's "Bot-Created PRs" section](task-workflow.instructions.md#bot-created-prs-mandatory-treat-as-your-own) ("Checking for existing work before branching"), which only catches work that already has a PR open.
+- **Before creating a new branch for an issue, check whether one already exists for it**: a previous session may have pushed work and then been interrupted before ever opening a PR. This is the branch-only counterpart to the PR check in [task-workflow.instructions.md's "Bot-Created PRs" section](task-workflow.instructions.md#bot-created-prs-mandatory-treat-as-your-own) ("Checking for existing work before branching"). The glob matches the `<type>/<issue-number>-<name>` convention below (see [Branch Naming](#branch-naming)):
 
   ```bash
   git ls-remote --heads origin "*/<issue-number>-*"
   ```
 
-  - No match, or a match found but not ahead of `main`: branch fresh from `main` as normal.
-  - Match found and ahead of `main` (check with `git rev-list --count origin/main..<branch>`): check it out and continue from there instead of branching again, rebasing first per the bullet above if `origin/main` has advanced.
+  - No match: branch fresh from `main` as normal.
+  - Match found: fetch it and compare against `main`:
+
+    ```bash
+    git fetch origin <branch>
+    git rev-list --count origin/main..origin/<branch>
+    ```
+
+    - `0` (not ahead of `main`): branch fresh from `main` as normal.
+    - `>0`: check it out and continue from there instead of branching again, rebasing first per the bullet above if `origin/main` has advanced.
 
 ## Pushing Branches
 

--- a/ai/global/git.instructions.md
+++ b/ai/global/git.instructions.md
@@ -116,9 +116,8 @@ Before any command that can discard uncommitted work (`git reset --hard`, `git c
   git ls-remote --heads origin "*/<issue-number>-*"
   ```
 
-  - No match: branch fresh from `main` as normal.
-  - Match found, not ahead of `main`: treat the same as no match; branch fresh from `main`.
-  - Match found and ahead of `main`: check it out and continue from there instead of branching again; rebase onto `origin/main` first if it has advanced (see [Pre-Work Baseline Check](#pre-work-baseline-check-mandatory-before-starting-any-work) above). Do not open a second branch/PR for the same issue.
+  - No match, or a match found but not ahead of `main`: branch fresh from `main` as normal.
+  - Match found and ahead of `main` (check with `git rev-list --count origin/main..<branch>`): check it out and continue from there instead of branching again, rebasing first per the bullet above if `origin/main` has advanced.
 
 ## Pushing Branches
 

--- a/ai/global/git.instructions.md
+++ b/ai/global/git.instructions.md
@@ -113,8 +113,7 @@ Before any command that can discard uncommitted work (`git reset --hard`, `git c
 - **Before creating a new branch for an issue, check whether one already exists for it**: a previous session may have pushed work and then been interrupted before ever opening a PR. This is the branch-only counterpart to the PR check in [task-workflow.instructions.md's "Bot-Created PRs" section](task-workflow.instructions.md#bot-created-prs-mandatory-treat-as-your-own) ("Checking for existing work before branching"), which only catches work that already has a PR open.
 
   ```bash
-  gh api "repos/<owner>/<repo>/branches" --paginate --jq '.[].name' \
-    | grep -E "^[A-Za-z]+/<issue-number>\b"
+  git ls-remote --heads origin "*/<issue-number>-*"
   ```
 
   - No match: branch fresh from `main` as normal.

--- a/ai/global/task-workflow.instructions.md
+++ b/ai/global/task-workflow.instructions.md
@@ -107,6 +107,7 @@ github is configured to automatically create PRs from pushed branches. These PRs
 **Checking for existing work before branching (MANDATORY):**
 
 - Check branch names in all open PRs, not just PR authors. If any open PR's `headRefName` contains the issue number, that is your work from a prior session; resume it instead of creating a new branch.
+- This only catches work that already has a PR open. A branch pushed but never turned into a PR (session died first) needs the separate check in [git.instructions.md's Branching section](git.instructions.md#branching).
 
 ## PR Title, Body, and Label Sync (MANDATORY)
 


### PR DESCRIPTION
## Summary

- Add a check to `git.instructions.md`'s Branching section so a session picking up an approved issue looks for an already-pushed branch matching the issue number before creating a fresh one from main.
- Cross-reference the new check from `agent-roles.instructions.md`'s Issue Workflow: Plan First step 1, for both the board-configured and no-board approval routes.

## Why

A previous session can push a branch and then die (crash, timeout) before opening a pull request. Without this check, the next session picking up the same issue had no way to notice and would silently create a duplicate branch, orphaning the first one.

Companion human-readable learning: credfeto/credfeto-notes#384

Closes #1018